### PR TITLE
fix(web): keep glucose charts current during live updates

### DIFF
--- a/apps/web/__tests__/dashboard-live-panel.test.tsx
+++ b/apps/web/__tests__/dashboard-live-panel.test.tsx
@@ -9,6 +9,8 @@ import {
   listNightscoutConnections,
 } from "@/lib/api";
 
+const mockRefreshWindow = jest.fn();
+
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
     replace: jest.fn(),
@@ -174,6 +176,7 @@ jest.mock("@/components/DashboardTimeRangeProvider", () => ({
     label: "Last 24 hours",
     selection: { kind: "preset", range: "24h" },
     setSelection: jest.fn(),
+    refreshWindow: mockRefreshWindow,
     timeZone: "UTC",
   }),
 }));

--- a/apps/web/__tests__/dashboard/live-glucose-refresh.test.tsx
+++ b/apps/web/__tests__/dashboard/live-glucose-refresh.test.tsx
@@ -27,6 +27,7 @@ const getHistory = jest.mocked(getGlucoseHistoryByDateRange);
 const START = new Date("2026-09-06T10:00:00.000Z");
 const FIVE_MINUTES = 5 * 60_000;
 
+/** Exercise refresh effects with the real time-range provider and Strict Mode replay. */
 function Wrapper({ children }: { children: ReactNode }) {
   return (
     <StrictMode>
@@ -35,6 +36,7 @@ function Wrapper({ children }: { children: ReactNode }) {
   );
 }
 
+/** Connect incoming reading timestamps to the real history query for integration assertions. */
 function useLiveHistory(readingTimestamp?: string) {
   const range = useDashboardTimeRange();
   const refreshKey = useDashboardLiveRefresh(readingTimestamp);
@@ -42,6 +44,7 @@ function useLiveHistory(readingTimestamp?: string) {
   return { range, refreshKey, history };
 }
 
+/** Advance the simulated clock and flush timer-driven React updates and API promises. */
 async function advance(ms: number) {
   await act(async () => { jest.advanceTimersByTime(ms); });
 }
@@ -121,6 +124,29 @@ it("refreshes immediately for a new reading exactly at the throttle boundary", a
   expect(result.current.refreshKey).toBe(2);
 });
 
+it("retains the newest queued reading when an older duplicate arrives", async () => {
+  const { result, rerender } = renderHook(
+    ({ timestamp }) => useLiveHistory(timestamp),
+    { wrapper: Wrapper, initialProps: { timestamp: START.toISOString() } },
+  );
+  await advance(4 * 60_000);
+  const newestTimestamp = "2026-09-06T10:04:00.000Z";
+  rerender({ timestamp: newestTimestamp });
+  await advance(30_000);
+  // A -> B -> A must not cancel the work queued for B.
+  rerender({ timestamp: START.toISOString() });
+  await advance(30_000);
+  expect(result.current.refreshKey).toBe(2);
+  expect(result.current.range.currentWindow?.to).toBe("2026-09-06T10:05:00.000Z");
+
+  const calls = getHistory.mock.calls.length;
+  await advance(FIVE_MINUTES);
+  rerender({ timestamp: newestTimestamp });
+  await advance(FIVE_MINUTES);
+  expect(result.current.refreshKey).toBe(2);
+  expect(getHistory).toHaveBeenCalledTimes(calls);
+});
+
 it("keeps a custom historical window fixed across live updates", async () => {
   const { result, rerender } = renderHook(
     ({ timestamp }) => useLiveHistory(timestamp),
@@ -187,6 +213,7 @@ describe("chart refresh integration", () => {
     "%p plots fresh history with one request per refresh and keeps fixed-range refreshes working",
     async (Chart) => {
       let range: ReturnType<typeof useDashboardTimeRange>;
+      /** Drive either chart with the same refresh signal used by the dashboard page. */
       function LiveChart({ timestamp }: { timestamp: string }) {
         range = useDashboardTimeRange();
         const refreshKey = useDashboardLiveRefresh(timestamp);
@@ -219,6 +246,7 @@ describe("chart refresh integration", () => {
 
   it("preserves desktop zoom on live refresh and resets it when the selection changes", async () => {
     let range: ReturnType<typeof useDashboardTimeRange>;
+    /** Keep the desktop chart mounted while live timestamps and the selection change. */
     function LiveChart({ timestamp }: { timestamp: string }) {
       range = useDashboardTimeRange();
       const refreshKey = useDashboardLiveRefresh(timestamp);

--- a/apps/web/__tests__/dashboard/live-glucose-refresh.test.tsx
+++ b/apps/web/__tests__/dashboard/live-glucose-refresh.test.tsx
@@ -1,0 +1,245 @@
+import { StrictMode, type ReactNode } from "react";
+import { act, render, renderHook, screen } from "@testing-library/react";
+import uPlot from "uplot";
+import {
+  DashboardTimeRangeProvider,
+  useDashboardTimeRange,
+} from "@/components/DashboardTimeRangeProvider";
+import { useDashboardLiveRefresh } from "@/hooks/use-dashboard-live-refresh";
+import { useGlucoseHistory } from "@/hooks/use-glucose-history";
+import { getGlucoseHistoryByDateRange, type GlucoseHistoryReading } from "@/lib/api";
+import { GlucoseTrendChart } from "@/components/GlucoseTrendChart";
+import { MergedGlucoseTrendChart } from "@/components/MergedGlucoseTrendChart";
+
+jest.mock("@/lib/api", () => ({
+  getGlucoseHistory: jest.fn(),
+  getGlucoseHistoryByDateRange: jest.fn(),
+  getBolusReviewByDateRange: jest.fn(async () => ({ boluses: [], total_count: 0 })),
+  getPumpEventHistory: jest.fn(async () => ({ events: [], count: 0 })),
+}));
+
+jest.mock("uplot", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({ destroy: jest.fn() })),
+}));
+
+const getHistory = jest.mocked(getGlucoseHistoryByDateRange);
+const START = new Date("2026-09-06T10:00:00.000Z");
+const FIVE_MINUTES = 5 * 60_000;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <StrictMode>
+      <DashboardTimeRangeProvider>{children}</DashboardTimeRangeProvider>
+    </StrictMode>
+  );
+}
+
+function useLiveHistory(readingTimestamp?: string) {
+  const range = useDashboardTimeRange();
+  const refreshKey = useDashboardLiveRefresh(readingTimestamp);
+  const history = useGlucoseHistory("3h", range.currentWindow);
+  return { range, refreshKey, history };
+}
+
+async function advance(ms: number) {
+  await act(async () => { jest.advanceTimersByTime(ms); });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers().setSystemTime(START);
+  getHistory.mockReset().mockResolvedValue({ readings: [], count: 0 });
+});
+
+afterEach(() => { jest.useRealTimers(); });
+
+it("advances the history query and includes a reading received after the page opened", async () => {
+  const newReading: GlucoseHistoryReading = {
+    value: 145,
+    reading_timestamp: "2026-09-06T10:04:00.000Z",
+    received_at: "2026-09-06T10:04:00.000Z",
+    trend: "flat",
+    trend_rate: null,
+    source: "dexcom",
+  };
+  getHistory.mockImplementation(async (_from, to) => {
+    const readings = newReading.reading_timestamp < to ? [newReading] : [];
+    return { readings, count: readings.length };
+  });
+  const { result, rerender } = renderHook(
+    ({ timestamp }) => useLiveHistory(timestamp),
+    { wrapper: Wrapper, initialProps: { timestamp: START.toISOString() } },
+  );
+  await advance(0);
+  expect(result.current.refreshKey).toBe(1);
+  expect(result.current.history.readings).toEqual([]);
+  const selection = result.current.range.selection;
+
+  await advance(4 * 60_000);
+  rerender({ timestamp: newReading.reading_timestamp });
+  expect(result.current.refreshKey).toBe(1);
+  // No further SSE event is needed to flush this reading.
+  await advance(60_000);
+
+  expect(result.current.refreshKey).toBe(2);
+  // Keep the selection stable so a live refresh does not reset picker drafts.
+  expect(result.current.range.selection).toBe(selection);
+  expect(getHistory).toHaveBeenLastCalledWith(
+    "2026-09-05T10:05:00.000Z", "2026-09-06T10:05:00.000Z", 288,
+  );
+  expect(result.current.history.readings).toEqual([newReading]);
+});
+
+it("coalesces a burst without moving the trailing refresh deadline", async () => {
+  const { result, rerender } = renderHook(
+    ({ timestamp }) => useLiveHistory(timestamp),
+    { wrapper: Wrapper, initialProps: { timestamp: START.toISOString() } },
+  );
+  await advance(60_000);
+  rerender({ timestamp: "2026-09-06T10:01:00.000Z" });
+  await advance(3 * 60_000);
+  rerender({ timestamp: "2026-09-06T10:04:00.000Z" });
+  await advance(60_000);
+  expect(result.current.refreshKey).toBe(2);
+  const calls = getHistory.mock.calls.length;
+  // Duplicate glucose events and idle time must not trigger polling.
+  rerender({ timestamp: "2026-09-06T10:04:00.000Z" });
+  await advance(FIVE_MINUTES);
+  expect(result.current.refreshKey).toBe(2);
+  expect(getHistory).toHaveBeenCalledTimes(calls);
+});
+
+it("refreshes immediately for a new reading exactly at the throttle boundary", async () => {
+  const { result, rerender } = renderHook(
+    ({ timestamp }) => useLiveHistory(timestamp),
+    { wrapper: Wrapper, initialProps: { timestamp: START.toISOString() } },
+  );
+  await advance(FIVE_MINUTES);
+  await act(async () => {
+    rerender({ timestamp: "2026-09-06T10:05:00.000Z" });
+  });
+  expect(result.current.refreshKey).toBe(2);
+});
+
+it("keeps a custom historical window fixed across live updates", async () => {
+  const { result, rerender } = renderHook(
+    ({ timestamp }) => useLiveHistory(timestamp),
+    { wrapper: Wrapper, initialProps: { timestamp: START.toISOString() } },
+  );
+  const window = { from: "2026-09-01T10:00:00.000Z", to: "2026-09-02T10:00:00.000Z" };
+  await act(async () => {
+    result.current.range.setSelection({ kind: "custom", window });
+  });
+  await advance(FIVE_MINUTES);
+  await act(async () => {
+    rerender({ timestamp: "2026-09-06T10:05:00.000Z" });
+  });
+  expect(result.current.refreshKey).toBe(2);
+  expect(result.current.range.currentWindow).toBe(window);
+  expect(getHistory).toHaveBeenLastCalledWith(window.from, window.to, 288);
+});
+
+it("does not refresh without readings and cancels pending work on unmount", async () => {
+  const { result, rerender, unmount } = renderHook(
+    ({ timestamp }) => useLiveHistory(timestamp),
+    { wrapper: Wrapper, initialProps: { timestamp: undefined as string | undefined } },
+  );
+  await advance(0);
+  expect(result.current.refreshKey).toBe(0);
+  await act(async () => { rerender({ timestamp: START.toISOString() }); });
+  expect(result.current.refreshKey).toBe(1);
+  await advance(60_000);
+  rerender({ timestamp: "2026-09-06T10:01:00.000Z" });
+  const pendingTimers = jest.getTimerCount();
+  const calls = getHistory.mock.calls.length;
+  unmount();
+  expect(jest.getTimerCount()).toBeLessThan(pendingTimers);
+  await advance(FIVE_MINUTES);
+  expect(getHistory).toHaveBeenCalledTimes(calls);
+});
+
+describe("chart refresh integration", () => {
+  beforeEach(() => {
+    jest.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(640);
+    jest.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(300);
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    jest.mocked(uPlot).mockClear();
+    getHistory.mockImplementation(async (_from, to) => ({
+      readings: [{
+        value: to === START.toISOString() ? 120 : 145,
+        reading_timestamp: new Date(new Date(to).getTime() - 60_000).toISOString(),
+        received_at: to,
+        trend: "flat",
+        trend_rate: null,
+        source: "dexcom",
+      }],
+      count: 1,
+    }));
+  });
+
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  it.each([GlucoseTrendChart, MergedGlucoseTrendChart])(
+    "%p plots fresh history with one request per refresh and keeps fixed-range refreshes working",
+    async (Chart) => {
+      let range: ReturnType<typeof useDashboardTimeRange>;
+      function LiveChart({ timestamp }: { timestamp: string }) {
+        range = useDashboardTimeRange();
+        const refreshKey = useDashboardLiveRefresh(timestamp);
+        return <Chart refreshKey={refreshKey} />;
+      }
+      const { rerender } = render(<LiveChart timestamp={START.toISOString()} />, { wrapper: Wrapper });
+      await advance(0);
+      const initialCalls = getHistory.mock.calls.length;
+      await advance(4 * 60_000);
+      rerender(<LiveChart timestamp="2026-09-06T10:04:00.000Z" />);
+      await advance(60_000);
+      expect(getHistory).toHaveBeenCalledTimes(initialCalls + 1);
+      const chartCalls = jest.mocked(uPlot).mock.calls;
+      expect(chartCalls[chartCalls.length - 1][1]?.[1]).toContain(145);
+
+      await act(async () => {
+        range.setSelection({ kind: "custom", window: {
+          from: "2026-09-01T10:00:00.000Z", to: "2026-09-02T10:00:00.000Z",
+        } });
+      });
+      const fixedRangeCalls = getHistory.mock.calls.length;
+      await advance(FIVE_MINUTES);
+      await act(async () => { rerender(<LiveChart timestamp="2026-09-06T10:10:00.000Z" />); });
+      expect(getHistory).toHaveBeenCalledTimes(fixedRangeCalls + 1);
+      expect(getHistory).toHaveBeenLastCalledWith(
+        "2026-09-01T10:00:00.000Z", "2026-09-02T10:00:00.000Z", 288,
+      );
+    },
+  );
+
+  it("preserves desktop zoom on live refresh and resets it when the selection changes", async () => {
+    let range: ReturnType<typeof useDashboardTimeRange>;
+    function LiveChart({ timestamp }: { timestamp: string }) {
+      range = useDashboardTimeRange();
+      const refreshKey = useDashboardLiveRefresh(timestamp);
+      return <GlucoseTrendChart refreshKey={refreshKey} />;
+    }
+    const { rerender } = render(<LiveChart timestamp={START.toISOString()} />, { wrapper: Wrapper });
+    await advance(0);
+    const chartCalls = jest.mocked(uPlot).mock.calls;
+    const options = chartCalls[chartCalls.length - 1][0];
+    act(() => {
+      options.hooks?.setSelect?.[0]?.({
+        posToVal: (position: number) => START.getTime() / 1000 - 3600 + position * 60,
+        select: { left: 10, width: 20 },
+        setSelect: jest.fn(),
+      } as unknown as uPlot);
+    });
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toBeInTheDocument();
+    await advance(FIVE_MINUTES);
+    await act(async () => { rerender(<LiveChart timestamp="2026-09-06T10:05:00.000Z" />); });
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toBeInTheDocument();
+    await act(async () => { range.setSelection({ kind: "preset", range: "7d" }); });
+    expect(screen.queryByRole("button", { name: "Reset zoom" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/v2/(authenticated)/dashboard/page.tsx
+++ b/apps/web/src/app/v2/(authenticated)/dashboard/page.tsx
@@ -68,6 +68,7 @@ function mapLoopStatus(
   };
 }
 
+/** Coordinate live readings, throttled history refreshes, and dashboard summaries. */
 function DashboardPageContent() {
   const router = useRouter();
   const dashboardTimeRange = useDashboardTimeRange();

--- a/apps/web/src/app/v2/(authenticated)/dashboard/page.tsx
+++ b/apps/web/src/app/v2/(authenticated)/dashboard/page.tsx
@@ -38,6 +38,7 @@ import {
 import { useDashboardTimeRange } from "@/components/DashboardTimeRangeProvider";
 
 import { useGlucoseStreamContext } from "@/providers/glucose-stream-provider";
+import { useDashboardLiveRefresh } from "@/hooks/use-dashboard-live-refresh";
 import { useUserContext } from "@/providers/user-provider";
 import { useGlucoseUnit } from "@/hooks/use-glucose-unit";
 import { useTimeInRangeDetailStats } from "@/hooks/use-time-in-range-stats";
@@ -75,18 +76,7 @@ function DashboardPageContent() {
   // All hooks must be called before any early return
   const { glucose, isLive, isReconnecting, error, reconnect } =
     useGlucoseStreamContext();
-  // Chart refresh: throttle to once per 5 minutes when new SSE data arrives
-  const [chartRefreshKey, setChartRefreshKey] = useState(0);
-  const lastRefreshRef = useRef(0);
-  useEffect(() => {
-    if (glucose?.reading_timestamp) {
-      const now = Date.now();
-      if (now - lastRefreshRef.current > 5 * 60 * 1000) {
-        lastRefreshRef.current = now;
-        setChartRefreshKey((k) => k + 1);
-      }
-    }
-  }, [glucose?.reading_timestamp]);
+  const chartRefreshKey = useDashboardLiveRefresh(glucose?.reading_timestamp);
   // Fetch user's configured glucose range thresholds (always mg/dL; display
   // converts to the active unit).
   const glucoseThresholds = useGlucoseRange();

--- a/apps/web/src/components/DashboardTimeRangeProvider/DashboardTimeRangeProvider.tsx
+++ b/apps/web/src/components/DashboardTimeRangeProvider/DashboardTimeRangeProvider.tsx
@@ -2,6 +2,7 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -46,31 +47,41 @@ export function getSelectionLabel(selection: HistorySelection, timeZone: string)
   return selection.label ?? formatTimeRangeLabel(selection.window, timeZone);
 }
 
-function resolveSelectionWindow(selection: HistorySelection, timeZone: string): HistoryWindow | null {
+function resolveSelectionWindow(selection: HistorySelection, timeZone: string, now: Date): HistoryWindow | null {
   if (selection.kind === "custom") {
     return selection.window;
   }
 
-  return resolveRawTimeRange(getPresetRawTimeRange(selection.range), { timeZone })?.window ?? null;
+  return resolveRawTimeRange(getPresetRawTimeRange(selection.range), { timeZone, now })?.window ?? null;
 }
 
 export function DashboardTimeRangeProvider({
   children,
   defaultRange = "24h",
 }: DashboardTimeRangeProviderProps) {
-  const [selection, setSelection] = useState<HistorySelection>({
-    kind: "preset",
-    range: defaultRange,
-  });
+  const [{ selection, now }, setRange] = useState<{ selection: HistorySelection; now: Date }>(() => ({
+    selection: { kind: "preset", range: defaultRange },
+    now: new Date(),
+  }));
   const [timeZone] = useState(getTimeZone);
+  const setSelection = useCallback((selection: HistorySelection) => {
+    setRange({ selection, now: new Date() });
+  }, []);
+  const refreshWindow = useCallback(() => {
+    // Re-resolve rolling presets against now; historical selections stay fixed.
+    setRange((current) => current.selection.kind === "preset"
+      ? { ...current, now: new Date() }
+      : current);
+  }, []);
 
   const value = useMemo<DashboardTimeRangeContextValue>(() => ({
     selection,
-    currentWindow: resolveSelectionWindow(selection, timeZone),
+    currentWindow: resolveSelectionWindow(selection, timeZone, now),
     label: getSelectionLabel(selection, timeZone),
     timeZone,
     setSelection,
-  }), [selection, timeZone]);
+    refreshWindow,
+  }), [selection, timeZone, now, setSelection, refreshWindow]);
 
   return (
     <DashboardTimeRangeContext.Provider value={value}>

--- a/apps/web/src/components/DashboardTimeRangeProvider/DashboardTimeRangeProvider.tsx
+++ b/apps/web/src/components/DashboardTimeRangeProvider/DashboardTimeRangeProvider.tsx
@@ -47,6 +47,7 @@ export function getSelectionLabel(selection: HistorySelection, timeZone: string)
   return selection.label ?? formatTimeRangeLabel(selection.window, timeZone);
 }
 
+/** Resolve rolling presets against one instant, preserving fixed historical bounds. */
 function resolveSelectionWindow(selection: HistorySelection, timeZone: string, now: Date): HistoryWindow | null {
   if (selection.kind === "custom") {
     return selection.window;
@@ -55,6 +56,7 @@ function resolveSelectionWindow(selection: HistorySelection, timeZone: string, n
   return resolveRawTimeRange(getPresetRawTimeRange(selection.range), { timeZone, now })?.window ?? null;
 }
 
+/** Share a time selection and advance its rolling window without replacing the selection. */
 export function DashboardTimeRangeProvider({
   children,
   defaultRange = "24h",

--- a/apps/web/src/components/DashboardTimeRangeProvider/DashboardTimeRangeProvider.types.ts
+++ b/apps/web/src/components/DashboardTimeRangeProvider/DashboardTimeRangeProvider.types.ts
@@ -11,6 +11,8 @@ export interface DashboardTimeRangeContextValue {
   label: string;
   timeZone: string;
   setSelection: (selection: HistorySelection) => void;
+  /** Advance a rolling preset to now without changing a historical selection. */
+  refreshWindow: () => void;
 }
 
 export interface DashboardTimeRangeProviderProps {

--- a/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
+++ b/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
@@ -14,6 +14,7 @@ import { Icon } from "@/base/Icon";
 import type { GlucoseHistoryReading } from "@/lib/api";
 import { type ChartTimePeriod, PERIOD_TO_MS } from "@/lib/chart-periods";
 import { serializeTimeRangeClipboardValue } from "@/lib/glucose/time-range-clipboard";
+import { getSelectionKey } from "@/lib/glucose/history-selection";
 import {
   formatGlucose,
   mgdlToMmol,
@@ -1007,25 +1008,34 @@ export function GlucoseTrendChart({
   const [timelineHover, setTimelineHover] =
     useState<CombinedTimelineHover | null>(null);
   const prevRefreshKeyRef = useRef(refreshKey);
+  const currentWindow = dashboardTimeRange?.currentWindow;
+  const previousWindowRef = useRef(currentWindow);
 
   useEffect(() => {
+    const windowChanged = currentWindow !== previousWindowRef.current;
+    previousWindowRef.current = currentWindow;
     if (
       refreshKey !== undefined &&
       refreshKey > 0 &&
       refreshKey !== prevRefreshKeyRef.current
     ) {
       prevRefreshKeyRef.current = refreshKey;
+      // History hooks already fetch when their window changes.
+      if (windowChanged) return;
       refetch();
       refetchInsulin();
       refetchPump();
     }
-  }, [refreshKey, refetch, refetchInsulin, refetchPump]);
+  }, [refreshKey, currentWindow, refetch, refetchInsulin, refetchPump]);
 
+  const rangeSelectionKey = dashboardTimeRange
+    ? getSelectionKey(dashboardTimeRange.selection)
+    : `period:${period}`;
   useEffect(() => {
     setZoomDomain(null);
     setCopyError(null);
     setTimelineHover(null);
-  }, [dashboardTimeRange?.currentWindow]);
+  }, [rangeSelectionKey]);
 
   const data = useMemo(() => transformReadings(readings), [readings]);
   const doseTimelineData = useMemo(

--- a/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
+++ b/apps/web/src/components/GlucoseTrendChart/GlucoseTrendChart.tsx
@@ -971,6 +971,7 @@ export function isMultiDayChartDomain(
   return xDomain[1] - xDomain[0] >= MULTI_DAY_MIN_DURATION_MS;
 }
 
+/** Render glucose and insulin history with synchronized time bounds and persistent live zoom. */
 export function GlucoseTrendChart({
   refreshKey,
   className,

--- a/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.tsx
+++ b/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.tsx
@@ -38,6 +38,7 @@ function isMultiDay(domain: [number, number]): boolean {
   return domain[1] - domain[0] >= 3 * 24 * 60 * 60 * 1000;
 }
 
+/** Load shared history once per range update for the mobile and desktop merged charts. */
 export function MergedGlucoseTrendChart({
   className,
   forecast,

--- a/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.tsx
+++ b/apps/web/src/components/MergedGlucoseTrendChart/MergedGlucoseTrendChart.tsx
@@ -64,8 +64,12 @@ export function MergedGlucoseTrendChart({
   const refetchInsulin = insulin.refetch;
   const refetchPump = pump.refetch;
   const previousRefreshKey = useRef(refreshKey);
+  const currentWindow = dashboardTimeRange?.currentWindow;
+  const previousWindow = useRef(currentWindow);
 
   useEffect(() => {
+    const windowChanged = currentWindow !== previousWindow.current;
+    previousWindow.current = currentWindow;
     if (
       refreshKey === undefined ||
       refreshKey <= 0 ||
@@ -75,10 +79,12 @@ export function MergedGlucoseTrendChart({
     }
 
     previousRefreshKey.current = refreshKey;
+    // History hooks already fetch when their window changes.
+    if (windowChanged) return;
     refetchGlucose();
     refetchInsulin();
     refetchPump();
-  }, [refetchGlucose, refetchInsulin, refetchPump, refreshKey]);
+  }, [currentWindow, refetchGlucose, refetchInsulin, refetchPump, refreshKey]);
 
   const points = useMemo(
     () => transformMergedGlucoseReadings(glucose.readings),

--- a/apps/web/src/hooks/use-dashboard-live-refresh.ts
+++ b/apps/web/src/hooks/use-dashboard-live-refresh.ts
@@ -10,16 +10,36 @@ export function useDashboardLiveRefresh(readingTimestamp?: string): number {
   const { refreshWindow } = useDashboardTimeRange();
   const [refreshKey, setRefreshKey] = useState(0);
   const lastRefreshAt = useRef<number | null>(null);
-  const lastRefreshedReading = useRef<string | undefined>(undefined);
+  const lastRefreshedReading = useRef<number | null>(null);
+  const pendingReading = useRef<number | null>(null);
+  const pendingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (pendingTimer.current !== null) clearTimeout(pendingTimer.current);
+    pendingTimer.current = null;
+    pendingReading.current = null;
+  }, []);
 
   useEffect(() => {
-    if (!readingTimestamp || readingTimestamp === lastRefreshedReading.current) {
+    const readingTime = readingTimestamp ? Date.parse(readingTimestamp) : NaN;
+    if (
+      !Number.isFinite(readingTime) ||
+      readingTime <= (lastRefreshedReading.current ?? -Infinity) ||
+      readingTime <= (pendingReading.current ?? -Infinity)
+    ) {
       return;
     }
 
+    pendingReading.current = readingTime;
+    // Newer readings join the queued refresh without postponing its deadline.
+    // Older or duplicate events cannot cancel work that is already pending.
+    if (pendingTimer.current !== null) return;
+
     const refresh = () => {
       lastRefreshAt.current = Date.now();
-      lastRefreshedReading.current = readingTimestamp;
+      lastRefreshedReading.current = pendingReading.current;
+      pendingReading.current = null;
+      pendingTimer.current = null;
       // React batches the window and refresh key so all requests use the new range.
       refreshWindow();
       setRefreshKey((key) => key + 1);
@@ -33,8 +53,7 @@ export function useDashboardLiveRefresh(readingTimestamp?: string): number {
       return;
     }
 
-    const timeout = setTimeout(refresh, delay);
-    return () => clearTimeout(timeout);
+    pendingTimer.current = setTimeout(refresh, delay);
   }, [readingTimestamp, refreshWindow]);
 
   return refreshKey;

--- a/apps/web/src/hooks/use-dashboard-live-refresh.ts
+++ b/apps/web/src/hooks/use-dashboard-live-refresh.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useDashboardTimeRange } from "@/components/DashboardTimeRangeProvider";
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Coalesce live readings, retaining a trailing refresh for throttled updates. */
+export function useDashboardLiveRefresh(readingTimestamp?: string): number {
+  const { refreshWindow } = useDashboardTimeRange();
+  const [refreshKey, setRefreshKey] = useState(0);
+  const lastRefreshAt = useRef<number | null>(null);
+  const lastRefreshedReading = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!readingTimestamp || readingTimestamp === lastRefreshedReading.current) {
+      return;
+    }
+
+    const refresh = () => {
+      lastRefreshAt.current = Date.now();
+      lastRefreshedReading.current = readingTimestamp;
+      // React batches the window and refresh key so all requests use the new range.
+      refreshWindow();
+      setRefreshKey((key) => key + 1);
+    };
+    const delay = lastRefreshAt.current === null
+      ? 0
+      : Math.max(0, REFRESH_INTERVAL_MS - (Date.now() - lastRefreshAt.current));
+
+    if (delay === 0) {
+      refresh();
+      return;
+    }
+
+    const timeout = setTimeout(refresh, delay);
+    return () => clearTimeout(timeout);
+  }, [readingTimestamp, refreshWindow]);
+
+  return refreshKey;
+}


### PR DESCRIPTION
## 📋 Summary

When the dashboard stayed open, Live CGM received new readings while the trend charts kept querying a time window ending when the page opened. Advance rolling preset windows at each live chart refresh, and schedule a trailing refresh for readings received during the existing five-minute throttle interval.

## 🔗 Related Issues

Reported while using the live dashboard; no linked issue.

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔨 Changes Made

- Resolve rolling preset windows against the refresh time while keeping custom historical ranges and the selected preset stable.
- Coalesce stream updates with a trailing timer; handle readings exactly at the five-minute boundary, preserve pending work across older duplicate events, and cancel pending work on unmount.
- Avoid duplicate history requests when the window and refresh key change together, and preserve desktop zoom during live window advances.
- Add nine regression cases covering the history query, plotted readings in both chart variants, throttling, out-of-order duplicates, historical ranges, request counts, and zoom. Update the dashboard page's context mock.

## 🧪 Test Plan

- [x] Unit tests pass: `npm test -- --runInBand --modulePathIgnorePatterns '<rootDir>/.next/'` (247 suites, 2,296 tests).
- [x] New regression tests added.
- [x] `npm run typecheck` passes.
- [x] ESLint passes for all changed TypeScript files.
- [x] `npm run build` passes.
- [ ] Manual/visual testing performed.
- Docker integration: not applicable; no backend or container changes.

## ✅ Checklist

- [x] Self-review completed.
- [x] Code follows project style guidelines.
- [x] No hardcoded secrets, API keys, or credentials.
- [x] Changed files pass lint without warnings.
- Documentation: not applicable; restores existing live dashboard behavior.

## 📸 Screenshots

Not applicable; no visual layout changes.
