### PR TITLE
fix: tighten session-length spacing and add 14/30-day session presets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,10 +86,10 @@ SESSION_EXPIRE_HOURS=24
 # Bounds for the per-user session-length preference, in minutes. Users choose a
 # value in [MIN, MAX] from Settings; new/legacy accounts default to 24h. The
 # session cookie + JWT are minted with the user's choice at login.
-# Both bounds must be within 15..10080 and the range must include 1440.
-# Invalid bounds are rejected at startup.
+# Both bounds must be within 15..43200 (15m..30d) and the range must include
+# 1440. Invalid bounds are rejected at startup.
 SESSION_TIMEOUT_MIN_MINUTES=15
-SESSION_TIMEOUT_MAX_MINUTES=10080
+SESSION_TIMEOUT_MAX_MINUTES=43200
 
 # Backup
 BACKUP_SCHEDULE=0 2 * * *

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -46,9 +46,9 @@ class Settings(BaseSettings):
     # Bounds for the per-user web-session timeout (User.session_timeout_minutes).
     # These bound the value users may choose in Settings; the default itself is
     # the column server_default (1440 = 24h, matching session_expire_hours).
-    # Deployment bounds must include that default and stay within 15m .. 7d.
-    session_timeout_min_minutes: int = Field(default=15, ge=15, le=10080)
-    session_timeout_max_minutes: int = Field(default=10080, ge=15, le=10080)
+    # Deployment bounds must include that default and stay within 15m .. 30d.
+    session_timeout_min_minutes: int = Field(default=15, ge=15, le=43200)
+    session_timeout_max_minutes: int = Field(default=43200, ge=15, le=43200)
 
     @model_validator(mode="after")
     def validate_session_timeout_bounds(self) -> "Settings":

--- a/apps/api/src/schemas/session_timeout.py
+++ b/apps/api/src/schemas/session_timeout.py
@@ -10,9 +10,10 @@ from pydantic import BaseModel, Field, field_validator
 
 from src.config import settings
 
-# Preset ladder surfaced by clients (minutes): 15m, 1h, 6h, 12h, 24h, 7d. This
-# is advisory for the UI only -- the API accepts any value within the bounds.
-SESSION_TIMEOUT_PRESET_MINUTES = [15, 60, 360, 720, 1440, 10080]
+# Preset ladder surfaced by clients (minutes): 15m, 1h, 6h, 12h, 24h, 7d, 14d,
+# 30d. This is advisory for the UI only -- the API accepts any value within the
+# bounds, and clients hide presets that fall outside the deployment range.
+SESSION_TIMEOUT_PRESET_MINUTES = [15, 60, 360, 720, 1440, 10080, 20160, 43200]
 
 
 class SessionTimeoutResponse(BaseModel):

--- a/apps/api/tests/test_session_timeout_setting.py
+++ b/apps/api/tests/test_session_timeout_setting.py
@@ -50,7 +50,7 @@ async def test_get_session_timeout_defaults_to_24h(client):
     assert body["minutes"] == 1440  # 24h, matching the historical default
     assert body["min_minutes"] == settings.session_timeout_min_minutes
     assert body["max_minutes"] == settings.session_timeout_max_minutes
-    assert body["presets"] == [15, 60, 360, 720, 1440, 10080]
+    assert body["presets"] == [15, 60, 360, 720, 1440, 10080, 20160, 43200]
 
 
 async def test_patch_session_timeout_round_trips(client):
@@ -65,6 +65,20 @@ async def test_patch_session_timeout_round_trips(client):
     assert update.status_code == 200
     assert update.json()["minutes"] == 360
     assert settings_get.json()["minutes"] == 360
+
+
+async def test_patch_accepts_thirty_day_session(client):
+    """The extended preset ladder (up to 30 days) is accepted, not clamped."""
+    cookies = await register_and_login(client)
+
+    update = await client.patch(
+        "/api/settings/session-timeout", json={"minutes": 43200}, cookies=cookies
+    )
+    settings_get = await client.get("/api/settings/session-timeout", cookies=cookies)
+
+    assert update.status_code == 200
+    assert update.json()["minutes"] == 43200  # 30 days
+    assert settings_get.json()["minutes"] == 43200
 
 
 async def test_patch_below_minimum_is_rejected(client):
@@ -207,7 +221,8 @@ async def test_changed_timeout_shortens_next_login_token_and_cookie(client):
 
 
 @pytest.mark.parametrize(
-    "low,high", [(15, 10080), (60, 1440), (1440, 1440), (1440, 10080)]
+    "low,high",
+    [(15, 10080), (60, 1440), (1440, 1440), (1440, 10080), (15, 43200)],
 )
 def test_config_accepts_ordered_session_timeout_bounds(low, high):
     """Deployment bounds allow both ranges and a single permitted duration."""
@@ -233,9 +248,9 @@ def test_config_rejects_inverted_session_timeout_bounds():
 @pytest.mark.parametrize(
     "field", ["session_timeout_min_minutes", "session_timeout_max_minutes"]
 )
-@pytest.mark.parametrize("value", [-1, 0, 14, 10081])
+@pytest.mark.parametrize("value", [-1, 0, 14, 43201])
 def test_config_rejects_session_timeout_outside_absolute_bounds(field, value):
-    """Neither deployment bound may escape the absolute 15-minute to 7-day range."""
+    """Neither deployment bound may escape the absolute 15-minute to 30-day range."""
     with pytest.raises(ValidationError) as exc:
         Settings(_env_file=None, **{field: value})
     assert exc.value.errors()[0]["loc"] == (field,)

--- a/apps/web/src/app/v2/(authenticated)/settings/profile/ProfileSettings.tsx
+++ b/apps/web/src/app/v2/(authenticated)/settings/profile/ProfileSettings.tsx
@@ -187,6 +187,16 @@ export function ProfileSettings({
     };
   }, [showsSessionLength]);
 
+  // The Session section renders only once its preference has loaded; while it is
+  // absent (still loading, or a failed best-effort fetch) the Password section
+  // is the last one on the account page and must keep the bottom scroll-spacer
+  // itself, so it is never obscured at the bottom of the viewport.
+  const sessionSectionVisible =
+    showsSessionLength &&
+    !isLoading &&
+    profile !== null &&
+    sessionMinutes !== null;
+
   const handleUpdateName = async (e: React.FormEvent) => {
     e.preventDefault();
     setHasAttemptedDisplayNameSave(true);
@@ -597,7 +607,18 @@ export function ProfileSettings({
 
       {showsAccount && !isLoading && profile && (
         <SettingsSection
-          className={spaciousSections ? "before:-top-16" : undefined}
+          // Owns the bottom scroll-spacer only when Session (which follows it)
+          // isn't rendered — otherwise Password would be the last section with
+          // no breathing room below it.
+          className={
+            sessionSectionVisible
+              ? spaciousSections
+                ? "before:-top-16"
+                : undefined
+              : spaciousSections
+                ? "pb-[40vh] before:-top-16"
+                : "pb-[40vh]"
+          }
           description="Use a strong password that you do not reuse elsewhere."
           separated
           title="Password"
@@ -667,11 +688,11 @@ export function ProfileSettings({
         </SettingsSection>
       )}
 
-      {showsSessionLength && !isLoading && profile && sessionMinutes !== null && (
+      {sessionSectionVisible && (
         <SettingsSection
-          // Last section on the account page: carries the bottom scroll-spacer
-          // so the page has breathing room below it (previously on Password,
-          // which is no longer last now that Session follows it).
+          // Last section on the account page when it renders: carries the bottom
+          // scroll-spacer so the page has breathing room below it. When it is
+          // absent, the Password section above takes the spacer instead.
           className={
             spaciousSections ? "pb-[40vh] before:-top-16" : "pb-[40vh]"
           }

--- a/apps/web/src/app/v2/(authenticated)/settings/profile/ProfileSettings.tsx
+++ b/apps/web/src/app/v2/(authenticated)/settings/profile/ProfileSettings.tsx
@@ -597,9 +597,7 @@ export function ProfileSettings({
 
       {showsAccount && !isLoading && profile && (
         <SettingsSection
-          className={
-            spaciousSections ? "pb-[40vh] before:-top-16" : "pb-[40vh]"
-          }
+          className={spaciousSections ? "before:-top-16" : undefined}
           description="Use a strong password that you do not reuse elsewhere."
           separated
           title="Password"
@@ -671,7 +669,12 @@ export function ProfileSettings({
 
       {showsSessionLength && !isLoading && profile && sessionMinutes !== null && (
         <SettingsSection
-          className={spaciousSections ? "before:-top-16" : undefined}
+          // Last section on the account page: carries the bottom scroll-spacer
+          // so the page has breathing room below it (previously on Password,
+          // which is no longer last now that Session follows it).
+          className={
+            spaciousSections ? "pb-[40vh] before:-top-16" : "pb-[40vh]"
+          }
           separated
           title="Session"
         >

--- a/apps/web/src/app/v2/(authenticated)/settings/profile/page.test.tsx
+++ b/apps/web/src/app/v2/(authenticated)/settings/profile/page.test.tsx
@@ -207,11 +207,11 @@ describe("ProfilePage", () => {
     expect(screen.getByLabelText("Current Password")).toBeInTheDocument();
     expect(screen.getByLabelText("New Password")).toBeInTheDocument();
     expect(screen.getByLabelText("Confirm New Password")).toBeInTheDocument();
-    // The bottom scroll-spacer moved to the (now last) Session section, so the
-    // Password section no longer strands ~40vh of empty space below it.
+    // Session length hasn't loaded here, so Password is the last section and
+    // keeps the bottom scroll-spacer (so it is never obscured at the bottom).
     expect(
       screen.getByLabelText("Current Password").closest("section"),
-    ).not.toHaveClass("pb-[40vh]");
+    ).toHaveClass("pb-[40vh]");
     expect(
       screen.getByRole("button", { name: "Change Password" }),
     ).toBeDisabled();
@@ -757,8 +757,30 @@ describe("ProfilePage", () => {
     expect(mockGetSessionTimeout).toHaveBeenCalledTimes(1);
     // 1440 minutes from the mocked preference -> the "24 hours" preset.
     expect(select).toHaveValue("1440");
-    // Session is the last account section, so it carries the bottom scroll-spacer.
+    // Session is the last account section, so it carries the bottom scroll-spacer,
+    // and the Password section above no longer does.
     expect(select.closest("section")).toHaveClass("pb-[40vh]");
+    expect(
+      screen.getByLabelText("Current Password").closest("section"),
+    ).not.toHaveClass("pb-[40vh]");
+  });
+
+  it("keeps the bottom spacer on Password when the session preference fails to load", async () => {
+    // If getSessionTimeout() rejects, the Session section never renders, so the
+    // Password section is last and must retain the scroll-spacer itself rather
+    // than leaving the final section obscured at the bottom of the viewport.
+    mockGetSessionTimeout.mockRejectedValue(new Error("network"));
+    render(<ProfileSettings sections={["account"]} />);
+
+    await screen.findByLabelText("Current Password");
+    await waitFor(() => expect(mockGetSessionTimeout).toHaveBeenCalled());
+
+    expect(
+      screen.queryByRole("combobox", { name: "Session length" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Current Password").closest("section"),
+    ).toHaveClass("pb-[40vh]");
   });
 
   it("saves a new session length and reflects it, applying at next sign-in", async () => {

--- a/apps/web/src/app/v2/(authenticated)/settings/profile/page.test.tsx
+++ b/apps/web/src/app/v2/(authenticated)/settings/profile/page.test.tsx
@@ -90,10 +90,10 @@ const PROFILE: CurrentUserResponse = {
 };
 
 const SESSION_TIMEOUT: SessionTimeoutResponse = {
-  max_minutes: 10080,
+  max_minutes: 43200,
   min_minutes: 15,
   minutes: 1440,
-  presets: [15, 60, 360, 720, 1440, 10080],
+  presets: [15, 60, 360, 720, 1440, 10080, 20160, 43200],
 };
 
 const refreshUser = jest.fn();
@@ -207,9 +207,11 @@ describe("ProfilePage", () => {
     expect(screen.getByLabelText("Current Password")).toBeInTheDocument();
     expect(screen.getByLabelText("New Password")).toBeInTheDocument();
     expect(screen.getByLabelText("Confirm New Password")).toBeInTheDocument();
+    // The bottom scroll-spacer moved to the (now last) Session section, so the
+    // Password section no longer strands ~40vh of empty space below it.
     expect(
       screen.getByLabelText("Current Password").closest("section"),
-    ).toHaveClass("pb-[40vh]");
+    ).not.toHaveClass("pb-[40vh]");
     expect(
       screen.getByRole("button", { name: "Change Password" }),
     ).toBeDisabled();
@@ -755,6 +757,8 @@ describe("ProfilePage", () => {
     expect(mockGetSessionTimeout).toHaveBeenCalledTimes(1);
     // 1440 minutes from the mocked preference -> the "24 hours" preset.
     expect(select).toHaveValue("1440");
+    // Session is the last account section, so it carries the bottom scroll-spacer.
+    expect(select.closest("section")).toHaveClass("pb-[40vh]");
   });
 
   it("saves a new session length and reflects it, applying at next sign-in", async () => {


### PR DESCRIPTION
## Summary
Two follow-up fixes to the per-user session-length feature (merged in #1002), both on the Account settings page:

1. **Spacing** — the Password section carried the `pb-[40vh]` bottom scroll-spacer meant for the page's *last* section, but the Session section now renders after it, stranding ~40vh of empty space between the Change Password box and the Session heading. Moved the spacer onto the (now last) Session section, so Password uses the same inter-section spacing as every other account section.
2. **14- & 30-day presets** — added `20160` (14d) and `43200` (30d) to the session-length preset ladder and raised the deployment session-timeout ceiling from 7 days to 30 days (default max + the absolute `Field` bound). The web client already formats these as "14 days" / "30 days"; deployments can still narrow the range via `SESSION_TIMEOUT_MAX_MINUTES`.

## Testing
- Backend `test_session_timeout_setting.py`: **28 passed** (against a migrated Postgres) — includes the extended preset list, a new 30-day round-trip test, and the raised-ceiling rejection (43201 now rejected).
- Frontend `profile/page.test.tsx`: **21 passed** — updated the spacer-placement assertions and the mock contract; plus 3 related settings/smoke suites (**39 passed**).
- `ruff` and `eslint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session timeout settings now support durations of up to 30 days.
  * Added 14-day and 30-day timeout presets where permitted by deployment settings.

* **Bug Fixes**
  * Improved account settings page scrolling by placing bottom spacing after the final Session section.
  * Preserved appropriate spacing when session-timeout settings are unavailable.

* **Tests**
  * Expanded coverage for 30-day timeout configuration, validation, presets, and settings-page layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->