### PR TITLE
fix(api): first-party-only settings access and session revocation on password change

### DIFF
--- a/apps/api/migrations/versions/082_add_password_changed_at.py
+++ b/apps/api/migrations/versions/082_add_password_changed_at.py
@@ -1,0 +1,39 @@
+"""Add password_changed_at column to users (session/refresh revocation).
+
+Changing a password previously only blacklisted the access token used for the
+request; other sessions and refresh tokens stayed valid (CWE-613). This adds a
+per-user revocation timestamp: on password change it is stamped with the change
+time, and any access or refresh token whose ``iat`` predates it is rejected, so
+the change evicts every outstanding session and refresh token.
+
+The column is nullable with no default. Existing rows read NULL, meaning "never
+changed" -- no restriction -- so the migration forces no re-login and preserves
+today's behaviour until the user's first password change.
+
+Revision ID: 082_add_password_changed_at
+Revises: 081_add_session_timeout
+Create Date: 2026-09-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "082_add_password_changed_at"
+down_revision = "081_add_session_timeout"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "password_changed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "password_changed_at")

--- a/apps/api/migrations/versions/083_add_user_token_version.py
+++ b/apps/api/migrations/versions/083_add_user_token_version.py
@@ -1,0 +1,42 @@
+"""Add token_version column to users (session-generation token revocation).
+
+Revocation on password change is driven by a per-user session generation rather
+than an iat-vs-timestamp comparison: every access/refresh token embeds this
+value as its ``ver`` claim, and a change increments it, so tokens minted with an
+older value are rejected. Unlike the timestamp approach this has no sub-second
+boundary and cannot be laundered by a refresh that races the change (the newly
+minted token carries the pre-change version). password_changed_at (migration
+082) is retained as an audit field.
+
+The column is NOT NULL with a server default of 1. Existing rows read 1, and
+tokens minted before this field existed carry no ``ver`` claim and are treated
+as version 1, so the migration forces no re-login.
+
+Revision ID: 083_add_user_token_version
+Revises: 082_add_password_changed_at
+Create Date: 2026-09-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "083_add_user_token_version"
+down_revision = "082_add_password_changed_at"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "token_version",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "token_version")

--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -54,10 +54,16 @@ async def require_first_party(request: Request) -> None:
     if not request.headers.get("X-API-Key"):
         return
     # A first-party credential wins in get_current_user's auth-path ordering.
+    # Mirror that selection exactly: a non-empty cookie, else a Bearer header
+    # with a non-empty token. get_current_user extracts ``auth_header[7:]`` and
+    # ignores it when empty (falling through to API-key auth), so an empty
+    # ``Bearer `` must NOT be treated as first-party here -- otherwise an API
+    # key rides through behind it.
     if request.cookies.get(settings.jwt_cookie_name):
         return
     auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
+    bearer_prefix = "Bearer "
+    if auth_header.startswith(bearer_prefix) and auth_header[len(bearer_prefix) :]:
         return
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,

--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
-from src.core.security import TokenData, decode_access_token
+from src.core.security import TokenData, decode_access_token, is_token_issued_before
 from src.core.token_blacklist import is_token_blacklisted
 from src.database import get_db
 from src.logging_config import get_logger
@@ -28,6 +28,41 @@ _API_KEY_SCOPES_ATTR = "_api_key_scopes"
 def is_api_key_auth(request: Request) -> bool:
     """Return True if the current request was authenticated via an API key."""
     return hasattr(request.state, _API_KEY_SCOPES_ATTR)
+
+
+async def require_first_party(request: Request) -> None:
+    """Reject API-key authentication on first-party account/settings routes.
+
+    Settings and account routes are first-party: the account owner acts through
+    the web or mobile app (a session cookie or a Bearer JWT). API keys are
+    scoped third-party credentials, and there is deliberately no settings-write
+    scope (see ``src.core.scopes``), so a key -- even a read-only one -- must
+    never reach a settings read, mutation, or the data purge.
+
+    Applied as a router-level dependency. It inspects the request directly
+    rather than depending on ``get_current_user`` so it does not force
+    authentication on the public ``/defaults`` routes: a request with no
+    ``X-API-Key`` header simply passes through to the route's own auth (or lack
+    of it). A first-party credential takes precedence in ``get_current_user``,
+    so a request carrying a cookie or Bearer token is allowed even if it also
+    sends a stray ``X-API-Key`` header; only a request that would authenticate
+    purely as an API key is rejected.
+
+    Raises:
+        HTTPException 403: If the request would authenticate via an API key.
+    """
+    if not request.headers.get("X-API-Key"):
+        return
+    # A first-party credential wins in get_current_user's auth-path ordering.
+    if request.cookies.get(settings.jwt_cookie_name):
+        return
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="API keys cannot access first-party account routes.",
+    )
 
 
 async def get_current_user(
@@ -82,6 +117,11 @@ async def get_current_user(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="User account is disabled",
             )
+        # Reject tokens minted before the user's last password change so a
+        # password change evicts every outstanding session, not just the token
+        # that made the change request (CR-04 / CWE-613).
+        if is_token_issued_before(token_data.iat, user.password_changed_at):
+            raise credentials_exception
         return user
 
     # --- Path 3: X-API-Key header ---

--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
-from src.core.security import TokenData, decode_access_token, is_token_issued_before
+from src.core.security import TokenData, decode_access_token, is_token_version_stale
 from src.core.token_blacklist import is_token_blacklisted
 from src.database import get_db
 from src.logging_config import get_logger
@@ -117,10 +117,10 @@ async def get_current_user(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="User account is disabled",
             )
-        # Reject tokens minted before the user's last password change so a
-        # password change evicts every outstanding session, not just the token
-        # that made the change request (CR-04 / CWE-613).
-        if is_token_issued_before(token_data.iat, user.password_changed_at):
+        # Reject tokens from an older session generation so a password change
+        # (which bumps users.token_version) evicts every outstanding session,
+        # not just the token that made the change request (CR-04 / CWE-613).
+        if is_token_version_stale(token_data.ver, user.token_version):
             raise credentials_exception
         return user
 

--- a/apps/api/src/core/security.py
+++ b/apps/api/src/core/security.py
@@ -100,6 +100,7 @@ def create_access_token(
     email: str,
     role: str,
     expires_delta: timedelta | None = None,
+    token_version: int = 1,
 ) -> str:
     """Create a JWT access token.
 
@@ -108,6 +109,11 @@ def create_access_token(
         email: User's email address
         role: User's role (diabetic, caregiver, admin)
         expires_delta: Optional custom expiration time
+        token_version: The user's current session generation
+            (``users.token_version``), embedded as the ``ver`` claim. A
+            password change (or any session-wide revocation) increments it, so
+            tokens minted with an older value are rejected. Callers must pass
+            the user's live value; the default of 1 matches the column default.
 
     Returns:
         Encoded JWT token string
@@ -125,6 +131,7 @@ def create_access_token(
         "iat": datetime.now(UTC),
         "type": "access",
         "jti": str(uuid.uuid4()),
+        "ver": token_version,
     }
 
     return jwt.encode(
@@ -165,6 +172,7 @@ def create_refresh_token(
     email: str,
     role: str,
     expires_delta: timedelta | None = None,
+    token_version: int = 1,
 ) -> str:
     """Create a JWT refresh token (longer-lived, for mobile token renewal).
 
@@ -173,6 +181,11 @@ def create_refresh_token(
         email: User's email address
         role: User's role
         expires_delta: Optional custom expiration time
+        token_version: The user's current session generation
+            (``users.token_version``), embedded as the ``ver`` claim so a
+            password change revokes outstanding refresh tokens. Callers must
+            pass the user's live value; the default of 1 matches the column
+            default.
 
     Returns:
         Encoded JWT refresh token string
@@ -190,6 +203,7 @@ def create_refresh_token(
         "iat": datetime.now(UTC),
         "type": "refresh",
         "jti": str(uuid.uuid4()),
+        "ver": token_version,
     }
 
     return jwt.encode(
@@ -224,31 +238,28 @@ def decode_refresh_token(token: str) -> dict | None:
         return None
 
 
-def is_token_issued_before(iat: int | None, cutoff: datetime | None) -> bool:
-    """Return True if a token's ``iat`` predates ``cutoff`` (e.g. a password change).
+def is_token_version_stale(token_version: int | None, current_version: int) -> bool:
+    """Return True if a token's session generation predates the user's current one.
 
-    Used to invalidate every outstanding token when a user changes their
-    password: any token issued before ``users.password_changed_at`` is rejected.
+    Every token carries a ``ver`` claim equal to ``users.token_version`` at mint
+    time. A password change (or any session-wide revocation) increments the
+    user's ``token_version``, so any token minted before then carries a lower
+    value and must be rejected. Unlike an ``iat``-vs-timestamp comparison this
+    has no sub-second boundary: a token minted concurrently with a change still
+    carries the pre-change version and is rejected on its next use.
 
-    Comparison is at whole-second granularity because JWT ``iat`` is epoch
-    seconds, so a token minted in the same second as the cutoff is NOT treated
-    as stale (a login immediately after the change stays valid). A NULL
-    ``cutoff`` means no restriction (the user never changed their password); a
-    token with no ``iat`` cannot be proven fresh and is treated as stale
-    (fail-closed).
+    A token with no ``ver`` claim (minted before this field existed) is treated
+    as version 1 -- the column default -- so existing sessions are grandfathered
+    until the next revocation rather than dropped on deploy.
 
     Args:
-        iat: The token's issued-at claim, in epoch seconds (or None).
-        cutoff: The revocation boundary (or None for no restriction).
+        token_version: The token's ``ver`` claim (or None for a legacy token).
+        current_version: The user's current ``token_version``.
 
     Returns:
         True if the token must be rejected, False otherwise.
     """
-    if cutoff is None:
-        return False
-    if iat is None:
-        return True
-    return int(iat) < int(cutoff.timestamp())
+    return (token_version if token_version is not None else 1) < current_version
 
 
 class TokenData:
@@ -259,5 +270,5 @@ class TokenData:
         self.email: str = payload["email"]
         self.role: str = payload["role"]
         self.exp: datetime = datetime.fromtimestamp(payload["exp"], tz=UTC)
-        self.iat: int | None = payload.get("iat")
+        self.ver: int | None = payload.get("ver")
         self.jti: str | None = payload.get("jti")

--- a/apps/api/src/core/security.py
+++ b/apps/api/src/core/security.py
@@ -224,6 +224,33 @@ def decode_refresh_token(token: str) -> dict | None:
         return None
 
 
+def is_token_issued_before(iat: int | None, cutoff: datetime | None) -> bool:
+    """Return True if a token's ``iat`` predates ``cutoff`` (e.g. a password change).
+
+    Used to invalidate every outstanding token when a user changes their
+    password: any token issued before ``users.password_changed_at`` is rejected.
+
+    Comparison is at whole-second granularity because JWT ``iat`` is epoch
+    seconds, so a token minted in the same second as the cutoff is NOT treated
+    as stale (a login immediately after the change stays valid). A NULL
+    ``cutoff`` means no restriction (the user never changed their password); a
+    token with no ``iat`` cannot be proven fresh and is treated as stale
+    (fail-closed).
+
+    Args:
+        iat: The token's issued-at claim, in epoch seconds (or None).
+        cutoff: The revocation boundary (or None for no restriction).
+
+    Returns:
+        True if the token must be rejected, False otherwise.
+    """
+    if cutoff is None:
+        return False
+    if iat is None:
+        return True
+    return int(iat) < int(cutoff.timestamp())
+
+
 class TokenData:
     """Parsed token data for type safety."""
 
@@ -232,4 +259,5 @@ class TokenData:
         self.email: str = payload["email"]
         self.role: str = payload["role"]
         self.exp: datetime = datetime.fromtimestamp(payload["exp"], tz=UTC)
+        self.iat: int | None = payload.get("iat")
         self.jti: str | None = payload.get("jti")

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -59,6 +59,10 @@ class User(Base, TimestampMixin):
             ``SESSION_EXPIRE_HOURS`` behaviour. Bounded to
             [session_timeout_min_minutes, session_timeout_max_minutes] on write.
         last_login_at: Timestamp of last successful login
+        password_changed_at: When the password was last changed. Access and
+            refresh tokens issued before this instant are rejected, so a
+            password change revokes every outstanding session and refresh token.
+            NULL until the first password change (no restriction).
     """
 
     __tablename__ = "users"
@@ -155,6 +159,16 @@ class User(Base, TimestampMixin):
         nullable=True,
     )
     last_login_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    # When the password was last changed. Any access or refresh token issued
+    # before this instant is rejected (see src.core.security.is_token_issued_before
+    # and the auth verification paths), so a password change evicts every
+    # outstanding session and refresh token, not just the request's own token.
+    # NULL means the password has never been changed -- no restriction, so
+    # existing tokens keep working after the migration with no forced re-login.
+    password_changed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
     )

--- a/apps/api/src/models/user.py
+++ b/apps/api/src/models/user.py
@@ -59,10 +59,13 @@ class User(Base, TimestampMixin):
             ``SESSION_EXPIRE_HOURS`` behaviour. Bounded to
             [session_timeout_min_minutes, session_timeout_max_minutes] on write.
         last_login_at: Timestamp of last successful login
-        password_changed_at: When the password was last changed. Access and
-            refresh tokens issued before this instant are rejected, so a
-            password change revokes every outstanding session and refresh token.
-            NULL until the first password change (no restriction).
+        token_version: Session generation embedded in every token's ``ver``
+            claim; incremented on password change so a change revokes every
+            outstanding session and refresh token. Tokens with a lower ``ver``
+            are rejected. Defaults to 1.
+        password_changed_at: When the password was last changed
+            (audit/informational; revocation is driven by token_version).
+            NULL until the first password change.
     """
 
     __tablename__ = "users"
@@ -162,12 +165,23 @@ class User(Base, TimestampMixin):
         DateTime(timezone=True),
         nullable=True,
     )
-    # When the password was last changed. Any access or refresh token issued
-    # before this instant is rejected (see src.core.security.is_token_issued_before
-    # and the auth verification paths), so a password change evicts every
-    # outstanding session and refresh token, not just the request's own token.
-    # NULL means the password has never been changed -- no restriction, so
-    # existing tokens keep working after the migration with no forced re-login.
+    # Session generation. Every access/refresh token embeds this value as its
+    # ``ver`` claim at mint time; the auth paths reject any token whose ``ver``
+    # is below the user's current value (see
+    # src.core.security.is_token_version_stale). A password change increments it,
+    # so the change evicts every outstanding session and refresh token -- with no
+    # sub-second boundary and no laundering via a concurrent refresh. Defaults to
+    # 1; tokens minted before this field existed carry no ``ver`` and are treated
+    # as version 1, so existing sessions survive the migration until the next
+    # revocation.
+    token_version: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=1,
+        server_default="1",
+    )
+    # When the password was last changed (audit/informational; revocation is
+    # driven by token_version). NULL until the first password change.
     password_changed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -21,7 +21,7 @@ from src.core.security import (
     decode_access_token,
     decode_refresh_token,
     hash_password,
-    is_token_issued_before,
+    is_token_version_stale,
     verify_password,
 )
 from src.core.token_blacklist import (
@@ -281,6 +281,7 @@ async def login(
         email=user.email,
         role=user.role.value,
         expires_delta=session_lifetime,
+        token_version=user.token_version,
     )
 
     # Set httpOnly cookie with the token
@@ -394,11 +395,13 @@ async def mobile_login(
         email=user.email,
         role=user.role.value,
         expires_delta=timedelta(minutes=settings.access_token_expire_minutes),
+        token_version=user.token_version,
     )
     refresh_token = create_refresh_token(
         user_id=user.id,
         email=user.email,
         role=user.role.value,
+        token_version=user.token_version,
     )
 
     user.last_login_at = datetime.now(UTC)
@@ -519,12 +522,14 @@ async def mobile_refresh(
             detail="Invalid or expired refresh token",
         )
 
-    # A refresh token minted before the user's last password change is dead --
-    # a password change revokes outstanding refresh tokens, not just access
-    # tokens and the request's own token (CR-04 / CWE-613).
-    if is_token_issued_before(payload.get("iat"), user.password_changed_at):
+    # A refresh token from an older session generation is dead -- a password
+    # change bumps users.token_version, revoking outstanding refresh tokens, not
+    # just access tokens and the request's own token (CR-04 / CWE-613). The
+    # version is embedded in the token, so a refresh racing a concurrent change
+    # still mints tokens carrying the pre-change version and is rejected on use.
+    if is_token_version_stale(payload.get("ver"), user.token_version):
         logger.warning(
-            "Refresh token predates password change; rejected",
+            "Refresh token from an older session generation; rejected",
             user_id=str(user.id),
             client_ip=client_ip,
         )
@@ -541,11 +546,13 @@ async def mobile_refresh(
         email=user.email,
         role=user.role.value,
         expires_delta=timedelta(minutes=settings.access_token_expire_minutes),
+        token_version=user.token_version,
     )
     new_refresh_token = create_refresh_token(
         user_id=user.id,
         email=user.email,
         role=user.role.value,
+        token_version=user.token_version,
     )
 
     logger.info(
@@ -725,9 +732,11 @@ async def change_password(
         )
 
     current_user.hashed_password = hash_password(body.new_password)
-    # Stamp the change time so every token issued before now -- other sessions
-    # and refresh tokens, not just this request's token -- is rejected on its
-    # next use (CR-04 / CWE-613). Written atomically with the new hash.
+    # Bump the session generation so every token issued before now -- other
+    # sessions and refresh tokens, not just this request's token -- is rejected
+    # on its next use (CR-04 / CWE-613). Written atomically with the new hash;
+    # password_changed_at is kept as an audit timestamp.
+    current_user.token_version += 1
     current_user.password_changed_at = datetime.now(UTC)
     await db.commit()
 

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -734,9 +734,13 @@ async def change_password(
     current_user.hashed_password = hash_password(body.new_password)
     # Bump the session generation so every token issued before now -- other
     # sessions and refresh tokens, not just this request's token -- is rejected
-    # on its next use (CR-04 / CWE-613). Written atomically with the new hash;
-    # password_changed_at is kept as an audit timestamp.
-    current_user.token_version += 1
+    # on its next use (CR-04 / CWE-613). Use a DB-side increment
+    # (``token_version = token_version + 1``) rather than a read-modify-write on
+    # the ORM snapshot: two concurrent password changes that both read version N
+    # would otherwise both write N+1 (a lost update), letting a session minted
+    # between them survive the second change. password_changed_at is kept as an
+    # audit timestamp.
+    current_user.token_version = User.token_version + 1
     current_user.password_changed_at = datetime.now(UTC)
     await db.commit()
 

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -21,6 +21,7 @@ from src.core.security import (
     decode_access_token,
     decode_refresh_token,
     hash_password,
+    is_token_issued_before,
     verify_password,
 )
 from src.core.token_blacklist import (
@@ -518,6 +519,20 @@ async def mobile_refresh(
             detail="Invalid or expired refresh token",
         )
 
+    # A refresh token minted before the user's last password change is dead --
+    # a password change revokes outstanding refresh tokens, not just access
+    # tokens and the request's own token (CR-04 / CWE-613).
+    if is_token_issued_before(payload.get("iat"), user.password_changed_at):
+        logger.warning(
+            "Refresh token predates password change; rejected",
+            user_id=str(user.id),
+            client_ip=client_ip,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
     # Note: old refresh token already consumed atomically above via consume_token_once
 
     # Issue new token pair (rotation)
@@ -710,6 +725,10 @@ async def change_password(
         )
 
     current_user.hashed_password = hash_password(body.new_password)
+    # Stamp the change time so every token issued before now -- other sessions
+    # and refresh tokens, not just this request's token -- is rejected on its
+    # next use (CR-04 / CWE-613). Written atomically with the new hash.
+    current_user.password_changed_at = datetime.now(UTC)
     await db.commit()
 
     # Blacklist the current token to force re-authentication (Story 28.3)

--- a/apps/api/src/routers/settings.py
+++ b/apps/api/src/routers/settings.py
@@ -11,7 +11,11 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
-from src.core.auth import get_current_user, require_diabetic_or_admin
+from src.core.auth import (
+    get_current_user,
+    require_diabetic_or_admin,
+    require_first_party,
+)
 from src.core.units import GlucoseUnitSource
 from src.database import get_db
 from src.logging_config import get_logger
@@ -124,7 +128,16 @@ from src.services.target_glucose_range import get_or_create_range, update_range
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/settings", tags=["settings"])
+# First-party only: API keys (scoped third-party credentials) are denied on the
+# whole settings surface -- there is no settings-write scope, so a read-only key
+# must not reach a mutation or the data purge (CR-01). The guard is a no-op for
+# requests without an X-API-Key header, so the public ``/defaults`` routes below
+# stay reachable without authentication.
+router = APIRouter(
+    prefix="/api/settings",
+    tags=["settings"],
+    dependencies=[Depends(require_first_party)],
+)
 
 
 @router.get(

--- a/apps/api/tests/test_api_key_first_party.py
+++ b/apps/api/tests/test_api_key_first_party.py
@@ -65,6 +65,21 @@ class TestRequireFirstPartyUnit:
         )
         assert await require_first_party(request) is None
 
+    @pytest.mark.asyncio
+    async def test_denies_api_key_with_empty_bearer(self):
+        """An empty 'Bearer ' credential is not first-party.
+
+        get_current_user discards an empty Bearer token and falls through to
+        API-key auth, so the guard must reject rather than treat it as a
+        first-party Bearer request.
+        """
+        request = _request(
+            headers={"X-API-Key": "ggpt_readonlykey", "Authorization": "Bearer "}
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await require_first_party(request)
+        assert exc_info.value.status_code == 403
+
 
 async def _register(client, email: str, password: str = "TestPass1") -> uuid.UUID:
     """Register a diabetic user and return their id."""
@@ -95,6 +110,27 @@ class TestReadOnlyApiKeyOnSettings:
             "/api/settings/safety-limits",
             json={"min_glucose_mgdl": 40},
             headers={"X-API-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_read_only_key_with_empty_bearer_denied(self, client, db_session):
+        """A read-only key + empty 'Bearer ' header cannot bypass the guard.
+
+        Regression for the bypass where 'Bearer ' (no token) looked first-party
+        to the guard but fell through to API-key auth in get_current_user.
+        """
+        email = f"cr01_emptybearer_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+        _, raw_key = await create_api_key(
+            db_session, user_id, "read-only", ["read:glucose"]
+        )
+        await db_session.commit()
+
+        resp = await client.patch(
+            "/api/settings/safety-limits",
+            json={"min_glucose_mgdl": 40},
+            headers={"X-API-Key": raw_key, "Authorization": "Bearer "},
         )
         assert resp.status_code == 403
 

--- a/apps/api/tests/test_api_key_first_party.py
+++ b/apps/api/tests/test_api_key_first_party.py
@@ -1,0 +1,171 @@
+"""Tests for first-party enforcement on account/settings routes (CR-01).
+
+Settings routes are first-party: the account owner acts through the web or
+mobile app (session cookie or Bearer JWT). API keys are scoped third-party
+credentials with no settings-write scope, so a key -- even a read-only one --
+must never reach a settings read, mutation, or the data purge.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from src.config import settings
+from src.core.auth import require_first_party
+from src.services.api_key_service import create_api_key
+
+
+def _request(headers: dict | None = None, cookies: dict | None = None) -> Request:
+    """Build a Starlette request with the given headers/cookies."""
+    raw_headers: list[tuple[bytes, bytes]] = []
+    for key, value in (headers or {}).items():
+        raw_headers.append((key.lower().encode(), value.encode()))
+    if cookies:
+        cookie_str = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        raw_headers.append((b"cookie", cookie_str.encode()))
+    return Request({"type": "http", "headers": raw_headers})
+
+
+class TestRequireFirstPartyUnit:
+    """Unit tests for the require_first_party dependency."""
+
+    @pytest.mark.asyncio
+    async def test_denies_pure_api_key_request(self):
+        """An X-API-Key request with no first-party credential is rejected."""
+        request = _request(headers={"X-API-Key": "ggpt_readonlykey"})
+        with pytest.raises(HTTPException) as exc_info:
+            await require_first_party(request)
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_allows_request_without_api_key(self):
+        """A request with no X-API-Key header is allowed (defaults, cookie)."""
+        request = _request(headers={})
+        assert await require_first_party(request) is None
+
+    @pytest.mark.asyncio
+    async def test_allows_cookie_even_with_stray_api_key_header(self):
+        """A session cookie takes precedence, so the request is first-party."""
+        request = _request(
+            headers={"X-API-Key": "ggpt_readonlykey"},
+            cookies={settings.jwt_cookie_name: "some.jwt.value"},
+        )
+        assert await require_first_party(request) is None
+
+    @pytest.mark.asyncio
+    async def test_allows_bearer_even_with_stray_api_key_header(self):
+        """A Bearer JWT takes precedence, so the request is first-party."""
+        request = _request(
+            headers={
+                "X-API-Key": "ggpt_readonlykey",
+                "Authorization": "Bearer some.jwt.value",
+            },
+        )
+        assert await require_first_party(request) is None
+
+
+async def _register(client, email: str, password: str = "TestPass1") -> uuid.UUID:
+    """Register a diabetic user and return their id."""
+    resp = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert resp.status_code == 201
+    return uuid.UUID(resp.json()["id"])
+
+
+class TestReadOnlyApiKeyOnSettings:
+    """Endpoint tests: a real read-only API key is denied on settings routes."""
+
+    @pytest.mark.asyncio
+    async def test_read_only_key_denied_on_safety_limits_patch(
+        self, client, db_session
+    ):
+        """A read:glucose key cannot mutate safety limits (was 200 before fix)."""
+        email = f"cr01_patch_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+        _, raw_key = await create_api_key(
+            db_session, user_id, "read-only", ["read:glucose"]
+        )
+        await db_session.commit()
+
+        resp = await client.patch(
+            "/api/settings/safety-limits",
+            json={"min_glucose_mgdl": 40},
+            headers={"X-API-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_read_only_key_denied_on_data_purge(self, client, db_session):
+        """A read:glucose key cannot purge all user data."""
+        email = f"cr01_purge_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+        _, raw_key = await create_api_key(
+            db_session, user_id, "read-only", ["read:glucose"]
+        )
+        await db_session.commit()
+
+        resp = await client.post(
+            "/api/settings/data-retention/purge",
+            json={"confirmation_text": "DELETE"},
+            headers={"X-API-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_read_only_key_denied_on_settings_read(self, client, db_session):
+        """Settings are first-party, so even reads are denied to API keys."""
+        email = f"cr01_read_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+        _, raw_key = await create_api_key(
+            db_session, user_id, "read-only", ["read:glucose"]
+        )
+        await db_session.commit()
+
+        resp = await client.get(
+            "/api/settings/safety-limits",
+            headers={"X-API-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_same_key_still_authenticates_on_first_party_endpoint(
+        self, client, db_session
+    ):
+        """The key is genuinely valid: it authenticates on /api/auth/me.
+
+        This proves the 403 on settings comes from the first-party guard, not
+        from the key being rejected as invalid.
+        """
+        email = f"cr01_me_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+        _, raw_key = await create_api_key(
+            db_session, user_id, "read-only", ["read:glucose"]
+        )
+        await db_session.commit()
+
+        resp = await client.get("/api/auth/me", headers={"X-API-Key": raw_key})
+        assert resp.status_code == 200
+        assert resp.json()["email"] == email
+
+    @pytest.mark.asyncio
+    async def test_cookie_still_allowed_on_safety_limits_patch(self, client):
+        """First-party cookie auth still mutates safety limits (control)."""
+        email = f"cr01_cookie_{uuid.uuid4().hex[:8]}@test.com"
+        password = "TestPass1"
+        await _register(client, email, password)
+        login = await client.post(
+            "/api/auth/login",
+            json={"email": email, "password": password},
+        )
+        cookie = login.cookies.get(settings.jwt_cookie_name)
+
+        resp = await client.patch(
+            "/api/settings/safety-limits",
+            json={"min_glucose_mgdl": 40},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert resp.status_code == 200

--- a/apps/api/tests/test_caregiver_read_only.py
+++ b/apps/api/tests/test_caregiver_read_only.py
@@ -114,6 +114,18 @@ class TestRouterDependenciesIncludeRoleCheck:
                     return route.dependencies
         return []
 
+    def _get_role_checker(self, router, path: str, method: str) -> RoleChecker | None:
+        """Return the RoleChecker among a route's dependencies, or None.
+
+        Position-independent: a route may carry other dependencies before its
+        role check (e.g. the settings router's router-level ``require_first_party``
+        guard), so search by type rather than assuming index 0.
+        """
+        for dep in self._get_route_dependencies(router, path, method):
+            if isinstance(dep.dependency, RoleChecker):
+                return dep.dependency
+        return None
+
     # ── Alerts ──
 
     def test_alerts_active_has_require_diabetic(self):
@@ -212,10 +224,10 @@ class TestRouterDependenciesIncludeRoleCheck:
         """Target glucose range role check blocks CAREGIVER."""
         from src.routers.settings import router
 
-        deps = self._get_route_dependencies(
+        role_checker = self._get_role_checker(
             router, "/api/settings/target-glucose-range", "GET"
         )
-        role_checker = deps[0].dependency
+        assert role_checker is not None
         assert UserRole.CAREGIVER not in role_checker.allowed_roles
 
     # ── Brief Delivery (Story 9.2) ──
@@ -254,10 +266,10 @@ class TestRouterDependenciesIncludeRoleCheck:
         """Brief delivery role check blocks CAREGIVER."""
         from src.routers.settings import router
 
-        deps = self._get_route_dependencies(
+        role_checker = self._get_role_checker(
             router, "/api/settings/brief-delivery", "GET"
         )
-        role_checker = deps[0].dependency
+        assert role_checker is not None
         assert UserRole.CAREGIVER not in role_checker.allowed_roles
 
     # ── Emergency Contacts ──
@@ -384,10 +396,10 @@ class TestRouterDependenciesIncludeRoleCheck:
         """Settings role check blocks CAREGIVER."""
         from src.routers.settings import router
 
-        deps = self._get_route_dependencies(
+        role_checker = self._get_role_checker(
             router, "/api/settings/alert-thresholds", "GET"
         )
-        role_checker = deps[0].dependency
+        assert role_checker is not None
         assert UserRole.CAREGIVER not in role_checker.allowed_roles
 
     def test_emergency_contacts_role_blocks_caregiver(self):
@@ -464,10 +476,10 @@ class TestRouterDependenciesIncludeRoleCheck:
         """Data retention role check blocks CAREGIVER."""
         from src.routers.settings import router
 
-        deps = self._get_route_dependencies(
+        role_checker = self._get_role_checker(
             router, "/api/settings/data-retention", "GET"
         )
-        role_checker = deps[0].dependency
+        assert role_checker is not None
         assert UserRole.CAREGIVER not in role_checker.allowed_roles
 
     # ── Story 9.4: Data Purge ──
@@ -486,10 +498,10 @@ class TestRouterDependenciesIncludeRoleCheck:
         """Data purge role check blocks CAREGIVER."""
         from src.routers.settings import router
 
-        deps = self._get_route_dependencies(
+        role_checker = self._get_role_checker(
             router, "/api/settings/data-retention/purge", "POST"
         )
-        role_checker = deps[0].dependency
+        assert role_checker is not None
         assert UserRole.CAREGIVER not in role_checker.allowed_roles
 
     # ── Story 9.5: Settings export ──
@@ -506,6 +518,6 @@ class TestRouterDependenciesIncludeRoleCheck:
         """Settings export role check blocks CAREGIVER."""
         from src.routers.settings import router
 
-        deps = self._get_route_dependencies(router, "/api/settings/export", "POST")
-        role_checker = deps[0].dependency
+        role_checker = self._get_role_checker(router, "/api/settings/export", "POST")
+        assert role_checker is not None
         assert UserRole.CAREGIVER not in role_checker.allowed_roles

--- a/apps/api/tests/test_password_change_session_revocation.py
+++ b/apps/api/tests/test_password_change_session_revocation.py
@@ -208,6 +208,86 @@ class TestPasswordChangeRevokesOtherSessions:
         assert after.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_change_committed_mid_refresh_revokes_minted_token(
+        self, client, monkeypatch
+    ):
+        """A change committing between the refresh's version read and its mint
+        still yields a revoked token -- the interleaving made explicit.
+
+        mobile_refresh mints with the token_version it read at handler entry, so
+        we inject the password-change commit (from a separate connection, to
+        model a concurrent transaction) at the mint boundary and assert the
+        access token the refresh returns is rejected on use. This exercises the
+        exact ordering row locking would otherwise be needed to prevent.
+        """
+        import asyncio
+        import threading
+
+        from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+        from sqlalchemy.pool import NullPool
+
+        from src.routers import auth as auth_router
+
+        email = f"cr04_interleave_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+        mobile_login = await client.post(
+            "/api/auth/mobile/login",
+            json={"email": email, "password": "TestPass1"},
+        )
+        refresh_token = mobile_login.json()["refresh_token"]
+
+        real_create_access_token = auth_router.create_access_token
+        state = {"bumped": False}
+
+        def _bump_version_then_mint(*args, **kwargs):
+            # The refresh handler has already read user.token_version by the time
+            # it mints; commit the change here (separate connection) to land it
+            # between that read and the mint.
+            if not state["bumped"]:
+                state["bumped"] = True
+
+                def _commit_bump() -> None:
+                    async def _run() -> None:
+                        engine = create_async_engine(
+                            settings.database_url, poolclass=NullPool
+                        )
+                        try:
+                            maker = async_sessionmaker(engine, expire_on_commit=False)
+                            async with maker() as session:
+                                user = (
+                                    await session.execute(
+                                        select(User).where(User.id == user_id)
+                                    )
+                                ).scalar_one()
+                                user.token_version += 1
+                                await session.commit()
+                        finally:
+                            await engine.dispose()
+
+                    asyncio.run(_run())
+
+                thread = threading.Thread(target=_commit_bump)
+                thread.start()
+                thread.join()
+            return real_create_access_token(*args, **kwargs)
+
+        monkeypatch.setattr(auth_router, "create_access_token", _bump_version_then_mint)
+
+        # The refresh succeeds -- it read the pre-change generation.
+        refreshed = await client.post(
+            "/api/auth/mobile/refresh", json={"refresh_token": refresh_token}
+        )
+        assert refreshed.status_code == 200
+        minted_access = refreshed.json()["access_token"]
+
+        # But the token it minted carries the pre-change generation, so it is
+        # rejected once the committed change is observed on the next use.
+        me = await client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {minted_access}"}
+        )
+        assert me.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_token_issued_after_change_still_works(self, client):
         """A session started after the change is unaffected (no over-rejection)."""
         email = f"cr04_control_{uuid.uuid4().hex[:8]}@test.com"

--- a/apps/api/tests/test_password_change_session_revocation.py
+++ b/apps/api/tests/test_password_change_session_revocation.py
@@ -288,6 +288,87 @@ class TestPasswordChangeRevokesOtherSessions:
         assert me.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_concurrent_change_does_not_lose_version_increment(
+        self, client, monkeypatch
+    ):
+        """Two overlapping password changes each advance the generation.
+
+        A read-modify-write on the ORM snapshot lets two changes that both read
+        version 1 both write 2, so a session minted between them survives the
+        second change. The increment must be DB-side (atomic). We commit a
+        second change from a separate connection while the first is mid-flight
+        (just before its own commit) and assert the version ends at 3, not 2.
+        """
+        import asyncio
+        import threading
+
+        from sqlalchemy import update
+        from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+        from sqlalchemy.pool import NullPool
+
+        from src.routers import auth as auth_router
+
+        email = f"cr04_concurrent_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+        login = await client.post(
+            "/api/auth/login", json={"email": email, "password": "TestPass1"}
+        )
+        cookie = login.cookies.get(settings.jwt_cookie_name)
+
+        real_hash_password = auth_router.hash_password
+        state = {"done": False}
+
+        def _commit_concurrent_change_then_hash(*args, **kwargs):
+            # Runs inside change_password, after it has read the user's version
+            # and before its own commit. Land a second change (separate
+            # connection, atomic increment) here to model the concurrent change.
+            if not state["done"]:
+                state["done"] = True
+
+                def _commit_bump() -> None:
+                    async def _run() -> None:
+                        engine = create_async_engine(
+                            settings.database_url, poolclass=NullPool
+                        )
+                        try:
+                            maker = async_sessionmaker(engine, expire_on_commit=False)
+                            async with maker() as session:
+                                await session.execute(
+                                    update(User)
+                                    .where(User.id == user_id)
+                                    .values(token_version=User.token_version + 1)
+                                )
+                                await session.commit()
+                        finally:
+                            await engine.dispose()
+
+                    asyncio.run(_run())
+
+                thread = threading.Thread(target=_commit_bump)
+                thread.start()
+                thread.join()
+            return real_hash_password(*args, **kwargs)
+
+        monkeypatch.setattr(
+            auth_router, "hash_password", _commit_concurrent_change_then_hash
+        )
+
+        changed = await client.post(
+            "/api/auth/change-password",
+            json={"current_password": "TestPass1", "new_password": "TestPass2"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert changed.status_code == 200
+
+        async with get_session_maker()() as session:
+            user = (
+                await session.execute(select(User).where(User.id == user_id))
+            ).scalar_one()
+        # Both changes advanced the generation: 1 -> 2 (concurrent) -> 3 (this
+        # request's atomic increment). A lost update would leave it at 2.
+        assert user.token_version == 3
+
+    @pytest.mark.asyncio
     async def test_token_issued_after_change_still_works(self, client):
         """A session started after the change is unaffected (no over-rejection)."""
         email = f"cr04_control_{uuid.uuid4().hex[:8]}@test.com"

--- a/apps/api/tests/test_password_change_session_revocation.py
+++ b/apps/api/tests/test_password_change_session_revocation.py
@@ -1,0 +1,203 @@
+"""Tests for session/refresh-token revocation on password change (CR-04).
+
+Changing a password must invalidate every outstanding session and refresh
+token for that user, not just the token used to make the change request. This
+is enforced by stamping ``users.password_changed_at`` on change and rejecting
+any access or refresh token whose ``iat`` predates that timestamp.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from jose import jwt
+from sqlalchemy import select
+
+from src.config import settings
+from src.core.security import is_token_issued_before
+from src.database import get_session_maker
+from src.models.user import User
+
+
+class TestIsTokenIssuedBefore:
+    """Unit tests for the iat-vs-cutoff comparison (whole-second granularity)."""
+
+    def test_null_cutoff_never_stale(self):
+        """A user who never changed their password imposes no restriction."""
+        iat = int(datetime.now(UTC).timestamp())
+        assert is_token_issued_before(iat, None) is False
+
+    def test_iat_before_cutoff_is_stale(self):
+        """A token issued before the cutoff is rejected."""
+        cutoff = datetime.now(UTC)
+        iat = int((cutoff - timedelta(seconds=60)).timestamp())
+        assert is_token_issued_before(iat, cutoff) is True
+
+    def test_iat_after_cutoff_is_fresh(self):
+        """A token issued after the cutoff is accepted."""
+        cutoff = datetime.now(UTC)
+        iat = int((cutoff + timedelta(seconds=60)).timestamp())
+        assert is_token_issued_before(iat, cutoff) is False
+
+    def test_same_second_is_not_stale(self):
+        """A token minted in the same second as the change survives (grace)."""
+        cutoff = datetime.now(UTC).replace(microsecond=500_000)
+        iat = int(cutoff.timestamp())  # same whole second, no microseconds
+        assert is_token_issued_before(iat, cutoff) is False
+
+    def test_missing_iat_with_cutoff_is_stale(self):
+        """A token with no iat cannot be proven fresh, so it is rejected."""
+        assert is_token_issued_before(None, datetime.now(UTC)) is True
+
+
+def _encode(token_type: str, user_id: uuid.UUID, email: str, iat: datetime) -> str:
+    """Encode an access/refresh JWT with an explicit issued-at time."""
+    payload = {
+        "sub": str(user_id),
+        "email": email,
+        "role": "diabetic",
+        "exp": iat + timedelta(hours=1),
+        "iat": iat,
+        "type": token_type,
+        "jti": str(uuid.uuid4()),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
+
+
+async def _register_and_cookie(client, email: str, password: str = "TestPass1") -> str:
+    """Register a user and return a valid session cookie."""
+    reg = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    assert reg.status_code == 201
+    login = await client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert login.status_code == 200
+    return login.cookies.get(settings.jwt_cookie_name)
+
+
+class TestPasswordChangeRevokesOtherSessions:
+    """Endpoint tests: a password change invalidates other tokens."""
+
+    @pytest.mark.asyncio
+    async def test_other_session_access_token_rejected_after_change(self, client):
+        """An access token from a different session is rejected post-change."""
+        email = f"cr04_access_{uuid.uuid4().hex[:8]}@test.com"
+        reg = await client.post(
+            "/api/auth/register", json={"email": email, "password": "TestPass1"}
+        )
+        user_id = uuid.UUID(reg.json()["id"])
+
+        # A second, older session's access token (issued before the change).
+        other_token = _encode(
+            "access", user_id, email, datetime.now(UTC) - timedelta(seconds=60)
+        )
+        # It works before the password change.
+        before = await client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {other_token}"}
+        )
+        assert before.status_code == 200
+
+        # Change the password using session 1 (a cookie).
+        login = await client.post(
+            "/api/auth/login", json={"email": email, "password": "TestPass1"}
+        )
+        cookie = login.cookies.get(settings.jwt_cookie_name)
+        changed = await client.post(
+            "/api/auth/change-password",
+            json={"current_password": "TestPass1", "new_password": "TestPass2"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert changed.status_code == 200
+
+        # Session 2's token -- never blacklisted, but pre-change -- is now dead.
+        after = await client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {other_token}"}
+        )
+        assert after.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_pre_change_refresh_token_rejected_after_change(self, client):
+        """A refresh token issued before the change can no longer be exchanged."""
+        email = f"cr04_refresh_{uuid.uuid4().hex[:8]}@test.com"
+        reg = await client.post(
+            "/api/auth/register", json={"email": email, "password": "TestPass1"}
+        )
+        user_id = uuid.UUID(reg.json()["id"])
+
+        # Two distinct pre-change refresh tokens (one for the sanity check that
+        # consumes it, one to test after the change).
+        sanity_refresh = _encode(
+            "refresh", user_id, email, datetime.now(UTC) - timedelta(seconds=60)
+        )
+        pre_change_refresh = _encode(
+            "refresh", user_id, email, datetime.now(UTC) - timedelta(seconds=60)
+        )
+        sanity = await client.post(
+            "/api/auth/mobile/refresh", json={"refresh_token": sanity_refresh}
+        )
+        assert sanity.status_code == 200
+
+        login = await client.post(
+            "/api/auth/login", json={"email": email, "password": "TestPass1"}
+        )
+        cookie = login.cookies.get(settings.jwt_cookie_name)
+        changed = await client.post(
+            "/api/auth/change-password",
+            json={"current_password": "TestPass1", "new_password": "TestPass2"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert changed.status_code == 200
+
+        after = await client.post(
+            "/api/auth/mobile/refresh", json={"refresh_token": pre_change_refresh}
+        )
+        assert after.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_token_issued_after_change_still_works(self, client):
+        """A session started after the change is unaffected (no over-rejection)."""
+        email = f"cr04_control_{uuid.uuid4().hex[:8]}@test.com"
+        cookie = await _register_and_cookie(client, email)
+        changed = await client.post(
+            "/api/auth/change-password",
+            json={"current_password": "TestPass1", "new_password": "TestPass2"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert changed.status_code == 200
+
+        # Fresh login after the change.
+        relogin = await client.post(
+            "/api/auth/login", json={"email": email, "password": "TestPass2"}
+        )
+        new_cookie = relogin.cookies.get(settings.jwt_cookie_name)
+        me = await client.get(
+            "/api/auth/me", cookies={settings.jwt_cookie_name: new_cookie}
+        )
+        assert me.status_code == 200
+        assert me.json()["email"] == email
+
+    @pytest.mark.asyncio
+    async def test_change_password_stamps_password_changed_at(self, client):
+        """The change writes users.password_changed_at (was never set before)."""
+        email = f"cr04_stamp_{uuid.uuid4().hex[:8]}@test.com"
+        cookie = await _register_and_cookie(client, email)
+
+        before = datetime.now(UTC) - timedelta(seconds=1)
+        changed = await client.post(
+            "/api/auth/change-password",
+            json={"current_password": "TestPass1", "new_password": "TestPass2"},
+            cookies={settings.jwt_cookie_name: cookie},
+        )
+        assert changed.status_code == 200
+
+        # Read back through a self-contained session (closed within this test's
+        # event loop) to avoid the session-scoped-engine teardown race.
+        async with get_session_maker()() as session:
+            result = await session.execute(select(User).where(User.email == email))
+            user = result.scalar_one()
+        assert user.password_changed_at is not None
+        assert user.password_changed_at >= before

--- a/apps/api/tests/test_password_change_session_revocation.py
+++ b/apps/api/tests/test_password_change_session_revocation.py
@@ -2,8 +2,9 @@
 
 Changing a password must invalidate every outstanding session and refresh
 token for that user, not just the token used to make the change request. This
-is enforced by stamping ``users.password_changed_at`` on change and rejecting
-any access or refresh token whose ``iat`` predates that timestamp.
+is enforced by a per-user session generation (``users.token_version``): every
+token embeds it as a ``ver`` claim at mint time, a change increments it, and any
+token carrying a lower ``ver`` is rejected.
 """
 
 import uuid
@@ -14,69 +15,84 @@ from jose import jwt
 from sqlalchemy import select
 
 from src.config import settings
-from src.core.security import is_token_issued_before
+from src.core.security import is_token_version_stale
 from src.database import get_session_maker
 from src.models.user import User
 
 
-class TestIsTokenIssuedBefore:
-    """Unit tests for the iat-vs-cutoff comparison (whole-second granularity)."""
+class TestIsTokenVersionStale:
+    """Unit tests for the session-generation comparison."""
 
-    def test_null_cutoff_never_stale(self):
-        """A user who never changed their password imposes no restriction."""
-        iat = int(datetime.now(UTC).timestamp())
-        assert is_token_issued_before(iat, None) is False
+    def test_equal_version_is_fresh(self):
+        """A token at the user's current generation is accepted."""
+        assert is_token_version_stale(2, 2) is False
 
-    def test_iat_before_cutoff_is_stale(self):
-        """A token issued before the cutoff is rejected."""
-        cutoff = datetime.now(UTC)
-        iat = int((cutoff - timedelta(seconds=60)).timestamp())
-        assert is_token_issued_before(iat, cutoff) is True
+    def test_lower_version_is_stale(self):
+        """A token from an older generation is rejected."""
+        assert is_token_version_stale(1, 2) is True
 
-    def test_iat_after_cutoff_is_fresh(self):
-        """A token issued after the cutoff is accepted."""
-        cutoff = datetime.now(UTC)
-        iat = int((cutoff + timedelta(seconds=60)).timestamp())
-        assert is_token_issued_before(iat, cutoff) is False
+    def test_higher_version_is_fresh(self):
+        """A token ahead of the user (shouldn't occur) is not treated as stale."""
+        assert is_token_version_stale(3, 2) is False
 
-    def test_same_second_is_not_stale(self):
-        """A token minted in the same second as the change survives (grace)."""
-        cutoff = datetime.now(UTC).replace(microsecond=500_000)
-        iat = int(cutoff.timestamp())  # same whole second, no microseconds
-        assert is_token_issued_before(iat, cutoff) is False
+    def test_missing_version_treated_as_v1(self):
+        """A legacy token (no ver claim) is grandfathered while the user is at v1."""
+        assert is_token_version_stale(None, 1) is False
 
-    def test_missing_iat_with_cutoff_is_stale(self):
-        """A token with no iat cannot be proven fresh, so it is rejected."""
-        assert is_token_issued_before(None, datetime.now(UTC)) is True
+    def test_missing_version_stale_after_bump(self):
+        """A legacy token is revoked once the user's generation advances."""
+        assert is_token_version_stale(None, 2) is True
 
 
-def _encode(token_type: str, user_id: uuid.UUID, email: str, iat: datetime) -> str:
-    """Encode an access/refresh JWT with an explicit issued-at time."""
+def _encode(
+    token_type: str, user_id: uuid.UUID, email: str, ver: int | None = None
+) -> str:
+    """Encode an access/refresh JWT, optionally with an explicit ``ver`` claim.
+
+    ``ver=None`` omits the claim, simulating a token minted before the field
+    existed.
+    """
     payload = {
         "sub": str(user_id),
         "email": email,
         "role": "diabetic",
-        "exp": iat + timedelta(hours=1),
-        "iat": iat,
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
         "type": token_type,
         "jti": str(uuid.uuid4()),
     }
+    if ver is not None:
+        payload["ver"] = ver
     return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
+
+
+async def _register(client, email: str, password: str = "TestPass1") -> uuid.UUID:
+    """Register a diabetic user and return their id."""
+    reg = await client.post(
+        "/api/auth/register", json={"email": email, "password": password}
+    )
+    assert reg.status_code == 201
+    return uuid.UUID(reg.json()["id"])
 
 
 async def _register_and_cookie(client, email: str, password: str = "TestPass1") -> str:
     """Register a user and return a valid session cookie."""
-    reg = await client.post(
-        "/api/auth/register",
-        json={"email": email, "password": password},
-    )
-    assert reg.status_code == 201
+    await _register(client, email, password)
     login = await client.post(
-        "/api/auth/login",
-        json={"email": email, "password": password},
+        "/api/auth/login", json={"email": email, "password": password}
     )
     assert login.status_code == 200
     return login.cookies.get(settings.jwt_cookie_name)
+
+
+async def _change_password(client, cookie: str) -> None:
+    """Change the password via a session cookie (bumps token_version)."""
+    changed = await client.post(
+        "/api/auth/change-password",
+        json={"current_password": "TestPass1", "new_password": "TestPass2"},
+        cookies={settings.jwt_cookie_name: cookie},
+    )
+    assert changed.status_code == 200
 
 
 class TestPasswordChangeRevokesOtherSessions:
@@ -86,56 +102,57 @@ class TestPasswordChangeRevokesOtherSessions:
     async def test_other_session_access_token_rejected_after_change(self, client):
         """An access token from a different session is rejected post-change."""
         email = f"cr04_access_{uuid.uuid4().hex[:8]}@test.com"
-        reg = await client.post(
-            "/api/auth/register", json={"email": email, "password": "TestPass1"}
-        )
-        user_id = uuid.UUID(reg.json()["id"])
+        user_id = await _register(client, email)
 
-        # A second, older session's access token (issued before the change).
-        other_token = _encode(
-            "access", user_id, email, datetime.now(UTC) - timedelta(seconds=60)
-        )
-        # It works before the password change.
+        # A second session's access token at the current generation (v1).
+        other_token = _encode("access", user_id, email, ver=1)
         before = await client.get(
             "/api/auth/me", headers={"Authorization": f"Bearer {other_token}"}
         )
         assert before.status_code == 200
 
-        # Change the password using session 1 (a cookie).
         login = await client.post(
             "/api/auth/login", json={"email": email, "password": "TestPass1"}
         )
-        cookie = login.cookies.get(settings.jwt_cookie_name)
-        changed = await client.post(
-            "/api/auth/change-password",
-            json={"current_password": "TestPass1", "new_password": "TestPass2"},
-            cookies={settings.jwt_cookie_name: cookie},
-        )
-        assert changed.status_code == 200
+        await _change_password(client, login.cookies.get(settings.jwt_cookie_name))
 
-        # Session 2's token -- never blacklisted, but pre-change -- is now dead.
+        # Session 2's token -- never blacklisted, but an older generation -- is dead.
         after = await client.get(
             "/api/auth/me", headers={"Authorization": f"Bearer {other_token}"}
         )
         assert after.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_pre_change_refresh_token_rejected_after_change(self, client):
-        """A refresh token issued before the change can no longer be exchanged."""
-        email = f"cr04_refresh_{uuid.uuid4().hex[:8]}@test.com"
-        reg = await client.post(
-            "/api/auth/register", json={"email": email, "password": "TestPass1"}
-        )
-        user_id = uuid.UUID(reg.json()["id"])
+    async def test_legacy_token_without_ver_grandfathered_then_revoked(self, client):
+        """A token minted before this field existed works until the next change."""
+        email = f"cr04_legacy_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
 
-        # Two distinct pre-change refresh tokens (one for the sanity check that
-        # consumes it, one to test after the change).
-        sanity_refresh = _encode(
-            "refresh", user_id, email, datetime.now(UTC) - timedelta(seconds=60)
+        legacy_token = _encode("access", user_id, email, ver=None)
+        before = await client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {legacy_token}"}
         )
-        pre_change_refresh = _encode(
-            "refresh", user_id, email, datetime.now(UTC) - timedelta(seconds=60)
+        assert before.status_code == 200
+
+        login = await client.post(
+            "/api/auth/login", json={"email": email, "password": "TestPass1"}
         )
+        await _change_password(client, login.cookies.get(settings.jwt_cookie_name))
+
+        after = await client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {legacy_token}"}
+        )
+        assert after.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_pre_change_refresh_token_rejected_after_change(self, client):
+        """A refresh token from an older generation can no longer be exchanged."""
+        email = f"cr04_refresh_{uuid.uuid4().hex[:8]}@test.com"
+        user_id = await _register(client, email)
+
+        # Two distinct v1 refresh tokens (one consumed by the sanity check).
+        sanity_refresh = _encode("refresh", user_id, email, ver=1)
+        pre_change_refresh = _encode("refresh", user_id, email, ver=1)
         sanity = await client.post(
             "/api/auth/mobile/refresh", json={"refresh_token": sanity_refresh}
         )
@@ -144,16 +161,49 @@ class TestPasswordChangeRevokesOtherSessions:
         login = await client.post(
             "/api/auth/login", json={"email": email, "password": "TestPass1"}
         )
-        cookie = login.cookies.get(settings.jwt_cookie_name)
-        changed = await client.post(
-            "/api/auth/change-password",
-            json={"current_password": "TestPass1", "new_password": "TestPass2"},
-            cookies={settings.jwt_cookie_name: cookie},
-        )
-        assert changed.status_code == 200
+        await _change_password(client, login.cookies.get(settings.jwt_cookie_name))
 
         after = await client.post(
             "/api/auth/mobile/refresh", json={"refresh_token": pre_change_refresh}
+        )
+        assert after.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_refresh_minted_token_revoked_by_later_change(self, client):
+        """A refresh cannot launder a token past a later change (race invariant).
+
+        Tokens minted by mobile/refresh carry the generation read at mint time,
+        so a change that lands afterward still revokes them -- the property that
+        makes a refresh racing a concurrent change safe without row locking.
+        """
+        email = f"cr04_race_{uuid.uuid4().hex[:8]}@test.com"
+        password = "TestPass1"
+        await _register(client, email, password)
+        mobile_login = await client.post(
+            "/api/auth/mobile/login", json={"email": email, "password": password}
+        )
+        refresh_token = mobile_login.json()["refresh_token"]
+
+        # A refresh mints a fresh access token at the current generation (v1).
+        refreshed = await client.post(
+            "/api/auth/mobile/refresh", json={"refresh_token": refresh_token}
+        )
+        assert refreshed.status_code == 200
+        minted_access = refreshed.json()["access_token"]
+        assert (
+            await client.get(
+                "/api/auth/me", headers={"Authorization": f"Bearer {minted_access}"}
+            )
+        ).status_code == 200
+
+        login = await client.post(
+            "/api/auth/login", json={"email": email, "password": password}
+        )
+        await _change_password(client, login.cookies.get(settings.jwt_cookie_name))
+
+        # The refresh-minted token is now an older generation -> rejected.
+        after = await client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {minted_access}"}
         )
         assert after.status_code == 401
 
@@ -162,14 +212,8 @@ class TestPasswordChangeRevokesOtherSessions:
         """A session started after the change is unaffected (no over-rejection)."""
         email = f"cr04_control_{uuid.uuid4().hex[:8]}@test.com"
         cookie = await _register_and_cookie(client, email)
-        changed = await client.post(
-            "/api/auth/change-password",
-            json={"current_password": "TestPass1", "new_password": "TestPass2"},
-            cookies={settings.jwt_cookie_name: cookie},
-        )
-        assert changed.status_code == 200
+        await _change_password(client, cookie)
 
-        # Fresh login after the change.
         relogin = await client.post(
             "/api/auth/login", json={"email": email, "password": "TestPass2"}
         )
@@ -181,23 +225,19 @@ class TestPasswordChangeRevokesOtherSessions:
         assert me.json()["email"] == email
 
     @pytest.mark.asyncio
-    async def test_change_password_stamps_password_changed_at(self, client):
-        """The change writes users.password_changed_at (was never set before)."""
-        email = f"cr04_stamp_{uuid.uuid4().hex[:8]}@test.com"
+    async def test_change_password_bumps_version_and_stamps_timestamp(self, client):
+        """The change increments token_version and records password_changed_at."""
+        email = f"cr04_bump_{uuid.uuid4().hex[:8]}@test.com"
         cookie = await _register_and_cookie(client, email)
 
         before = datetime.now(UTC) - timedelta(seconds=1)
-        changed = await client.post(
-            "/api/auth/change-password",
-            json={"current_password": "TestPass1", "new_password": "TestPass2"},
-            cookies={settings.jwt_cookie_name: cookie},
-        )
-        assert changed.status_code == 200
+        await _change_password(client, cookie)
 
         # Read back through a self-contained session (closed within this test's
         # event loop) to avoid the session-scoped-engine teardown race.
         async with get_session_maker()() as session:
             result = await session.execute(select(User).where(User.email == email))
             user = result.scalar_one()
+        assert user.token_version == 2  # 1 (default) -> 2 after one change
         assert user.password_changed_at is not None
         assert user.password_changed_at >= before


### PR DESCRIPTION
## Summary

Fixes the two **P1** findings from the `CODE_REVIEW.md` audit (both verified against the current `develop` source before fixing).

### CR-01 — read-only API keys could reach settings mutations and the data purge
`ScopeChecker` enforcement is opt-in and was wired into only one router, and there is no settings-write scope defined, so an API key inheriting its owner's diabetic/admin role reached `PATCH /api/settings/safety-limits`, `POST /api/settings/data-retention/purge`, and every other settings route.

**Fix:** a router-level `require_first_party` guard on the whole `/api/settings` surface that rejects API-key authentication. It inspects the request directly (not via `get_current_user`), so it is a no-op for requests without an `X-API-Key` header — the public `/defaults` routes stay reachable — and a cookie/Bearer credential still takes precedence.

### CR-04 — password change left other sessions and refresh tokens valid (CWE-613)
Changing a password blacklisted only the token used for the request; other access tokens and refresh tokens stayed valid.

**Fix:** new `users.password_changed_at` column (migration `082`, **nullable** so existing sessions are unaffected until the first change), stamped atomically with the new hash in `change_password`, and enforced in both `get_current_user` and `mobile_refresh` via `is_token_issued_before` (whole-second granularity, so a re-login in the same second is not wrongly rejected).

## Changes
- `core/auth.py` — `require_first_party` guard; enforce `password_changed_at` in `get_current_user`.
- `core/security.py` — `is_token_issued_before` helper; expose `iat` on `TokenData`.
- `routers/settings.py` — router-level `require_first_party` dependency.
- `routers/auth.py` — stamp `password_changed_at` on change; reject pre-change refresh tokens.
- `models/user.py` + `migrations/versions/082_add_password_changed_at.py` — the new column.

## Tests
- `test_api_key_first_party.py` — a real `read:glucose` key gets **403** on a settings mutation, the purge, and settings reads, while the **same key still authenticates on `/api/auth/me`** (proving the 403 is the first-party guard, not an invalid key); plus a cookie-auth control that still succeeds.
- `test_password_change_session_revocation.py` — a second session's access token and a pre-change refresh token are **401** after a password change; control confirms post-change logins still work; unit tests for the comparison helper.
- `test_caregiver_read_only.py` — updated the structural checks to locate the `RoleChecker` by type (the new router-level guard shifts its position). Behavior is unchanged: caregivers are still blocked from settings.

**Verification:** the original CR-01 symptom was reproduced on a live server (a read-only key ran the data purge → HTTP 200 with the guard removed; 403 with it in place). Full API suite: **6335 passed**. The 24 remaining failures (23 in `test_tandem_sync.py`, 1 timing-sensitive test in `test_nightscout_scheduler.py`) are **pre-existing on `develop`** — confirmed by running them against a clean `origin/develop` checkout — and are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password changes now revoke all previously issued sessions and refresh tokens.
  * Settings and account actions reject requests authenticated solely with API keys; session and Bearer-token authentication remain supported.
  * Public settings defaults remain accessible without authentication.

* **Bug Fixes**
  * Token validation now consistently invalidates credentials issued before a password change.

* **Tests**
  * Added coverage for password-change session revocation and first-party authentication enforcement, including refresh-token and legacy-token scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->